### PR TITLE
Replace Snake Yaml with Jackson object mapper using yaml factory

### DIFF
--- a/buildSrc/src/main/groovy/com.flipkart.varadhi.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.flipkart.varadhi.java-common-conventions.gradle
@@ -54,6 +54,7 @@ dependencies {
         annotationProcessor("org.projectlombok:lombok:$lombok_version")
 
         implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_version")
+        implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jackson_version")
 
         implementation("io.vertx:vertx-core:$vertx_version")
         implementation("io.vertx:vertx-config:${vertx_version}")

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -6,4 +6,5 @@ dependencies {
     implementation("io.vertx:vertx-core")
     implementation('org.yaml:snakeyaml:2.0')
     implementation('com.fasterxml.jackson.module:jackson-module-parameter-names:2.14.2')
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     implementation("io.vertx:vertx-core")
-    implementation('org.yaml:snakeyaml:2.0')
     implementation('com.fasterxml.jackson.module:jackson-module-parameter-names:2.14.2')
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
 }

--- a/common/src/main/java/com/flipkart/varadhi/utils/YamlLoader.java
+++ b/common/src/main/java/com/flipkart/varadhi/utils/YamlLoader.java
@@ -1,16 +1,22 @@
 package com.flipkart.varadhi.utils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.flipkart.varadhi.exceptions.VaradhiException;
-import org.yaml.snakeyaml.Yaml;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.File;
 
 public class YamlLoader {
 
+    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+    static {
+        mapper.findAndRegisterModules();
+    }
+
     public static <T> T loadConfig(String configFile, Class<T> clazz) {
         try {
-            return new Yaml().loadAs(Files.readString(Path.of(configFile)), clazz);
+            return mapper.readValue(new File(configFile), clazz);
         } catch (Exception e) {
             throw new VaradhiException(String.format("Failed to load config file: %s as %s.", configFile, clazz), e);
         }

--- a/common/src/test/java/com/flipkart/varadhi/utils/YamlLoaderTest.java
+++ b/common/src/test/java/com/flipkart/varadhi/utils/YamlLoaderTest.java
@@ -2,6 +2,8 @@ package com.flipkart.varadhi.utils;
 
 
 import com.flipkart.varadhi.exceptions.VaradhiException;
+import lombok.Getter;
+import lombok.Setter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -61,12 +63,13 @@ public class YamlLoaderTest {
         Path configFile = tempDir.resolve("config.yaml");
         String yamlContent = """
                 ---
-                genericConf:
+                nestedGenericConf:
                   k1:
                   - ABC
                   - XYZ
-                  k2:
-                  - XYZ
+                genericConf:
+                - ABC
+                - XYZ
                 """;
         Files.write(configFile, yamlContent.getBytes());
 
@@ -75,10 +78,12 @@ public class YamlLoaderTest {
 
         // Verify the loaded config
         Assertions.assertNotNull(config);
-        Assertions.assertTrue(config.getGenericConf().containsKey("k1"));
-        Assertions.assertNotNull(config.getGenericConf().get("k1").get(0));
-        Assertions.assertNotNull(config.getGenericConf().get("k1").get(0).getField());
-        Assertions.assertEquals("abc", config.getGenericConf().get("k1").get(0).getField());
+        Assertions.assertTrue(config.getNestedGenericConf().containsKey("k1"));
+        Assertions.assertNotNull(config.getNestedGenericConf().get("k1").get(0));
+        Assertions.assertEquals("abc", config.getNestedGenericConf().get("k1").get(0).getField());
+
+        Assertions.assertNotNull(config.getGenericConf().get(0));
+        Assertions.assertEquals("abc", config.getGenericConf().get(0).getField());
     }
 
     // Sample config class for testing
@@ -94,16 +99,11 @@ public class YamlLoaderTest {
         }
     }
 
+    @Getter
+    @Setter
     public static class GenericConfig {
-        private Map<String, List<MyEnum>> genericConf;
-
-        public Map<String, List<MyEnum>> getGenericConf() {
-            return genericConf;
-        }
-
-        public void setGenericConf(Map<String, List<MyEnum>> conf) {
-            genericConf = conf;
-        }
+        private Map<String, List<MyEnum>> nestedGenericConf;
+        private List<MyEnum> genericConf;
     }
 
     public enum MyEnum {

--- a/common/src/test/java/com/flipkart/varadhi/utils/YamlLoaderTest.java
+++ b/common/src/test/java/com/flipkart/varadhi/utils/YamlLoaderTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
 
 public class YamlLoaderTest {
 
@@ -54,6 +56,31 @@ public class YamlLoaderTest {
         });
     }
 
+    @Test
+    public void testLoadConfig_GenericConfig() throws IOException {
+        Path configFile = tempDir.resolve("config.yaml");
+        String yamlContent = """
+                ---
+                genericConf:
+                  k1:
+                  - ABC
+                  - XYZ
+                  k2:
+                  - XYZ
+                """;
+        Files.write(configFile, yamlContent.getBytes());
+
+        // Load the config using YamlLoader
+        GenericConfig config = YamlLoader.loadConfig(configFile.toString(), GenericConfig.class);
+
+        // Verify the loaded config
+        Assertions.assertNotNull(config);
+        Assertions.assertTrue(config.getGenericConf().containsKey("k1"));
+        Assertions.assertNotNull(config.getGenericConf().get("k1").get(0));
+        Assertions.assertNotNull(config.getGenericConf().get("k1").get(0).getField());
+        Assertions.assertEquals("abc", config.getGenericConf().get("k1").get(0).getField());
+    }
+
     // Sample config class for testing
     public static class Config {
         private String message;
@@ -64,6 +91,33 @@ public class YamlLoaderTest {
 
         public void setMessage(String message) {
             this.message = message;
+        }
+    }
+
+    public static class GenericConfig {
+        private Map<String, List<MyEnum>> genericConf;
+
+        public Map<String, List<MyEnum>> getGenericConf() {
+            return genericConf;
+        }
+
+        public void setGenericConf(Map<String, List<MyEnum>> conf) {
+            genericConf = conf;
+        }
+    }
+
+    public enum MyEnum {
+        ABC("abc"),
+        XYZ("xyz");
+
+        private final String field;
+
+        public String getField() {
+            return field;
+        }
+
+        MyEnum(String field) {
+            this.field = field;
         }
     }
 }

--- a/pulsar/build.gradle
+++ b/pulsar/build.gradle
@@ -5,6 +5,5 @@ dependencies {
     implementation(project(':common'))
     implementation(project(':core'))
     implementation(project(':entities'))
-    implementation('org.yaml:snakeyaml:2.0')
     implementation('org.apache.pulsar:pulsar-client-admin:2.10.0')
 }


### PR DESCRIPTION
SnakeYaml is not able to deserialise generic types properly.
`List<Enum>` is deserialised as a type erased `List` having String elements which leads to class cast exceptions.
I guess this is because of type erasure, it is not able to infer the correct type once the code is compiled.

However, I found that Jackson does not face this issue. How it is able to maintain the type information and avoid this problem, that is not known. But, for now we can safely replace usage of snake yaml with Jackson object mapper using YAMLFactory extension.

Following example demonstrates the issue:

Let's say we have a Config class:
```java
public class DefaultAuthorizationConfiguration {
    private Map<String, List<ResourceAction>> roles;
}
```

And the following YAML config:
```yaml
---
roles:
  org.admin:
    - ORG_CREATE
    - ORG_UPDATE
    - ORG_GET
    - ORG_DELETE
    - TEAM_CREATE
    - TEAM_GET
    - TEAM_UPDATE
    - PROJECT_GET
    - TOPIC_GET
```

Using the Snake Yaml reader we get the following deserialisation result:
![Screenshot 2023-10-17 at 2 59 15 PM](https://github.com/flipkart-incubator/varadhi/assets/135004899/023b9b4a-b83c-4d92-82eb-0472037c05cf)
Note that the values of map keys are raw `ArrayList` having `String` elements. But, we were expecting the type to be `ResourceAction`

Now using Jackson YAMLFactory based reader we get:
![Screenshot 2023-10-17 at 3 03 21 PM](https://github.com/flipkart-incubator/varadhi/assets/135004899/caba1f6b-5780-4c83-b736-8cbafea56b39)
Here we see that the elements of the list are deserialised with correct types.

Hence, the PR is raised to replace Snake Yaml with Jackson due to more predictable deserialisation results.
