### PR TITLE
Made entities the base module.

### DIFF
--- a/buildSrc/src/main/groovy/com.flipkart.varadhi.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.flipkart.varadhi.java-common-conventions.gradle
@@ -26,9 +26,11 @@ ext {
     jersey_version = "2.25.1"
     guava_version = "32.1.1-jre"
     curator_version = "5.5.0"
-    jackson_version = "2.14.2"
+    jackson_version = "2.15.1"
     jakarta_version = "3.0.2"
     commons_lang_version = "3.11"
+
+    hibernate_validator_version = "8.0.1.Final"
 }
 
 sourceSets {
@@ -46,6 +48,7 @@ configurations {
 }
 
 dependencies {
+    // TODO: Get rid of these unnecessary constraints. We are probably using it wrong. Need to check.
     constraints {
         implementation("org.slf4j:slf4j-api:$slf4j_version")
         implementation('org.apache.logging.log4j:log4j-slf4j2-impl:2.20.0')
@@ -55,6 +58,8 @@ dependencies {
         compileOnly("org.projectlombok:lombok:$lombok_version")
         annotationProcessor("org.projectlombok:lombok:$lombok_version")
 
+        implementation("com.fasterxml.jackson.core:jackson-annotations:$jackson_version")
+        testFixtures("com.fasterxml.jackson.core:jackson-annotations:$jackson_version")
         implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_version")
         implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jackson_version")
 
@@ -85,8 +90,8 @@ dependencies {
         implementation("io.micrometer:micrometer-registry-jmx:$micrometer_version")
         implementation("com.google.guava:guava:$guava_version")
 
-
         implementation("jakarta.validation:jakarta.validation-api:$jakarta_version")
+        testFixtures("jakarta.validation:jakarta.validation-api:$jakarta_version")
 
         testCompileOnly("org.projectlombok:lombok:$lombok_version")
         testAnnotationProcessor("org.projectlombok:lombok:$lombok_version")

--- a/buildSrc/src/main/groovy/com.flipkart.varadhi.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.flipkart.varadhi.java-common-conventions.gradle
@@ -58,8 +58,6 @@ dependencies {
         compileOnly("org.projectlombok:lombok:$lombok_version")
         annotationProcessor("org.projectlombok:lombok:$lombok_version")
 
-        implementation("com.fasterxml.jackson.core:jackson-annotations:$jackson_version")
-        testFixtures("com.fasterxml.jackson.core:jackson-annotations:$jackson_version")
         implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_version")
         implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jackson_version")
 
@@ -91,7 +89,6 @@ dependencies {
         implementation("com.google.guava:guava:$guava_version")
 
         implementation("jakarta.validation:jakarta.validation-api:$jakarta_version")
-        testFixtures("jakarta.validation:jakarta.validation-api:$jakarta_version")
 
         testCompileOnly("org.projectlombok:lombok:$lombok_version")
         testAnnotationProcessor("org.projectlombok:lombok:$lombok_version")

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,8 +1,9 @@
 plugins {
-    id 'com.flipkart.varadhi.java-published-library-conventions'
+    id 'com.flipkart.varadhi.java-library-conventions'
 }
 
 dependencies {
+    api(project(":entities"))
     implementation('com.fasterxml.jackson.module:jackson-module-parameter-names:2.14.2')
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
     implementation("io.micrometer:micrometer-core")

--- a/common/src/main/java/com/flipkart/varadhi/Constants.java
+++ b/common/src/main/java/com/flipkart/varadhi/Constants.java
@@ -1,10 +1,7 @@
 package com.flipkart.varadhi;
 
 public class Constants {
-    public static final String NAME_VALIDATION_PATTERN = "[a-z]{1}[a-z0-9_-]+[a-z0-9]{1}";
     public static final int RANDOM_PARTITION_KEY_LENGTH = 5;
-    public static int INITIAL_VERSION = 0;
-    public static String NAME_SEPARATOR = ".";
 
     public static class PathParams {
         public static final String REQUEST_PATH_PARAM_ORG = "org";

--- a/common/src/main/java/com/flipkart/varadhi/MessageConstants.java
+++ b/common/src/main/java/com/flipkart/varadhi/MessageConstants.java
@@ -1,5 +1,7 @@
 package com.flipkart.varadhi;
 
+import com.flipkart.varadhi.entities.StandardHeaders;
+
 import java.util.List;
 
 public class MessageConstants {
@@ -8,15 +10,13 @@ public class MessageConstants {
     public static String ANONYMOUS_PRODUCE_IDENTITY = "Anonymous";
 
     public static class Headers {
-        public static String VARADHI_HEADER_PREFIX = "x_";
-        public static String PRODUCE_TIMESTAMP = "x_restbus_produce_timestamp";
-        public static String PRODUCE_REGION = "x_restbus_produce_region";
-        public static String PRODUCE_IDENTITY = "x_restbus_produce_identity";
-        public static String FORWARDED_FOR = "x-forwarded-for";
-        public static String MESSAGE_ID = "x_restbus_message_id";
-        public static String GROUP_ID = "x_restbus_group_id";
-
         public static List<String> REQUIRED_HEADERS =
-                List.of(MESSAGE_ID, PRODUCE_IDENTITY, PRODUCE_REGION, PRODUCE_TIMESTAMP);
+                List.of(
+                        StandardHeaders.MESSAGE_ID,
+                        StandardHeaders.GROUP_ID,
+                        StandardHeaders.PRODUCE_IDENTITY,
+                        StandardHeaders.PRODUCE_REGION,
+                        StandardHeaders.PRODUCE_TIMESTAMP
+                );
     }
 }

--- a/common/src/main/java/com/flipkart/varadhi/MessageConstants.java
+++ b/common/src/main/java/com/flipkart/varadhi/MessageConstants.java
@@ -13,7 +13,6 @@ public class MessageConstants {
         public static List<String> REQUIRED_HEADERS =
                 List.of(
                         StandardHeaders.MESSAGE_ID,
-                        StandardHeaders.GROUP_ID,
                         StandardHeaders.PRODUCE_IDENTITY,
                         StandardHeaders.PRODUCE_REGION,
                         StandardHeaders.PRODUCE_TIMESTAMP

--- a/common/src/main/java/com/flipkart/varadhi/Result.java
+++ b/common/src/main/java/com/flipkart/varadhi/Result.java
@@ -1,7 +1,5 @@
 package com.flipkart.varadhi;
 
-import com.flipkart.varadhi.exceptions.ArgumentException;
-
 public class Result<T> {
     private final T result;
     private final Throwable cause;
@@ -13,7 +11,7 @@ public class Result<T> {
 
     public static <T> Result<T> of(T result, Throwable cause) {
         if (result != null && cause != null) {
-            throw new ArgumentException("Both result and cause can't be non null.");
+            throw new IllegalArgumentException("Both result and cause can't be non null.");
         }
         return new Result<>(result, cause);
     }

--- a/common/src/main/java/com/flipkart/varadhi/exceptions/ArgumentException.java
+++ b/common/src/main/java/com/flipkart/varadhi/exceptions/ArgumentException.java
@@ -1,7 +1,0 @@
-package com.flipkart.varadhi.exceptions;
-
-import lombok.experimental.StandardException;
-
-@StandardException
-public class ArgumentException extends VaradhiException {
-}

--- a/common/src/main/java/com/flipkart/varadhi/utils/MessageHelper.java
+++ b/common/src/main/java/com/flipkart/varadhi/utils/MessageHelper.java
@@ -1,6 +1,5 @@
 package com.flipkart.varadhi.utils;
 
-import com.flipkart.varadhi.exceptions.ArgumentException;
 import com.google.common.collect.Multimap;
 
 import static com.flipkart.varadhi.MessageConstants.Headers.REQUIRED_HEADERS;
@@ -10,7 +9,7 @@ public class MessageHelper {
     public static void ensureRequiredHeaders(Multimap<String, String> requestHeaders) {
         REQUIRED_HEADERS.forEach(key -> {
             if (!requestHeaders.containsKey(key)) {
-                throw new ArgumentException(String.format("Missing required header %s", key));
+                throw new IllegalArgumentException(String.format("Missing required header %s", key));
             }
         });
     }

--- a/common/src/main/java/com/flipkart/varadhi/utils/YamlLoader.java
+++ b/common/src/main/java/com/flipkart/varadhi/utils/YamlLoader.java
@@ -3,6 +3,7 @@ package com.flipkart.varadhi.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.flipkart.varadhi.entities.Validator;
 import com.flipkart.varadhi.exceptions.InvalidConfigException;
 
 import java.io.File;

--- a/common/src/test/java/com/flipkart/varadhi/ResultTest.java
+++ b/common/src/test/java/com/flipkart/varadhi/ResultTest.java
@@ -1,6 +1,5 @@
 package com.flipkart.varadhi;
 
-import com.flipkart.varadhi.exceptions.ArgumentException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +14,7 @@ public class ResultTest {
         Assertions.assertEquals("some data", r.result());
         Assertions.assertNull(r.cause());
 
-        ArgumentException e = new ArgumentException("some error");
+        IllegalArgumentException e = new IllegalArgumentException("some error");
         r = Result.of(e);
         Assertions.assertFalse(r.hasResult());
         Assertions.assertTrue(r.hasFailed());
@@ -39,7 +38,8 @@ public class ResultTest {
         Assertions.assertFalse(r.hasFailed());
         Assertions.assertNull(r.result());
         Assertions.assertNull(r.cause());
-        ArgumentException ee = Assertions.assertThrows(ArgumentException.class, () -> Result.of("some data", e));
+        IllegalArgumentException ee =
+                Assertions.assertThrows(IllegalArgumentException.class, () -> Result.of("some data", e));
         Assertions.assertEquals("Both result and cause can't be non null.", ee.getMessage());
     }
 }

--- a/common/src/test/java/com/flipkart/varadhi/utils/MessageHelperTest.java
+++ b/common/src/test/java/com/flipkart/varadhi/utils/MessageHelperTest.java
@@ -1,19 +1,21 @@
 package com.flipkart.varadhi.utils;
 
-import com.flipkart.varadhi.exceptions.ArgumentException;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static com.flipkart.varadhi.MessageConstants.Headers.*;
+import static com.flipkart.varadhi.MessageConstants.Headers.REQUIRED_HEADERS;
+import static com.flipkart.varadhi.entities.StandardHeaders.MESSAGE_ID;
+import static com.flipkart.varadhi.entities.StandardHeaders.PRODUCE_REGION;
 
 public class MessageHelperTest {
     @Test
     public void testAllRequiredHeadersPresent() {
         Multimap<String, String> varadhiHeaders = ArrayListMultimap.create();
         varadhiHeaders.put("Header1", "value1");
-        REQUIRED_HEADERS.forEach(key -> varadhiHeaders.put(key, String.format("%s_sometext", key)));
+        REQUIRED_HEADERS.forEach(
+                key -> varadhiHeaders.put(key, String.format("%s_sometext", key)));
         varadhiHeaders.put("Header2", "value2");
         varadhiHeaders.put("x_header1", "value1");
         MessageHelper.ensureRequiredHeaders(varadhiHeaders);
@@ -27,14 +29,14 @@ public class MessageHelperTest {
                 .forEach(key -> varadhiHeaders.put(key, String.format("%s_sometext", key)));
         varadhiHeaders.put("Header2", "value2");
         varadhiHeaders.put("x_header1", "value1");
-        ArgumentException ae = Assertions.assertThrows(
-                ArgumentException.class,
+        IllegalArgumentException ae = Assertions.assertThrows(
+                IllegalArgumentException.class,
                 () -> MessageHelper.ensureRequiredHeaders(varadhiHeaders)
         );
         Assertions.assertEquals("Missing required header x_restbus_message_id", ae.getMessage());
         varadhiHeaders.put(MESSAGE_ID, "somme random text");
         ae = Assertions.assertThrows(
-                ArgumentException.class,
+                IllegalArgumentException.class,
                 () -> MessageHelper.ensureRequiredHeaders(varadhiHeaders)
         );
         Assertions.assertEquals("Missing required header x_restbus_produce_region", ae.getMessage());

--- a/consumer/build.gradle
+++ b/consumer/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id 'com.flipkart.varadhi.java-library-conventions'
+}
+
+dependencies {
+    
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,9 +5,9 @@ plugins {
 
 dependencies {
     implementation(project(':common'))
-    implementation(project(':entities'))
     implementation('com.fasterxml.jackson.core:jackson-databind')
+
+    testFixturesImplementation(project(":common"))
     testImplementation(project(':pulsar'))
-    testFixturesImplementation(project(':entities'))
-    testFixturesImplementation(project(':common'))
+    testImplementation('com.fasterxml.jackson.core:jackson-annotations')
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,5 +9,4 @@ dependencies {
 
     testFixturesImplementation(project(":common"))
     testImplementation(project(':pulsar'))
-    testImplementation('com.fasterxml.jackson.core:jackson-annotations')
 }

--- a/core/src/main/java/com/flipkart/varadhi/core/VaradhiTopicFactory.java
+++ b/core/src/main/java/com/flipkart/varadhi/core/VaradhiTopicFactory.java
@@ -4,8 +4,6 @@ package com.flipkart.varadhi.core;
 import com.flipkart.varadhi.entities.*;
 import com.flipkart.varadhi.spi.services.StorageTopicFactory;
 
-import static com.flipkart.varadhi.Constants.NAME_SEPARATOR;
-
 public class VaradhiTopicFactory {
 
     private final StorageTopicFactory<StorageTopic> topicFactory;
@@ -35,7 +33,7 @@ public class VaradhiTopicFactory {
         StorageTopic storageTopic =
                 topicFactory.getTopic(varadhiTopic.getName(), project, capacityPolicy);
         // This is likely to change with replicated topics across zones. To be taken care as part of DR.
-        String internalTopicName = String.join(NAME_SEPARATOR, varadhiTopic.getName(), deploymentRegion);
+        String internalTopicName = String.join(AbstractTopic.NAME_SEPARATOR, varadhiTopic.getName(), deploymentRegion);
         InternalTopic internalTopic = new InternalTopic(
                 internalTopicName,
                 deploymentRegion,

--- a/core/src/main/java/com/flipkart/varadhi/core/VaradhiTopicFactory.java
+++ b/core/src/main/java/com/flipkart/varadhi/core/VaradhiTopicFactory.java
@@ -4,7 +4,7 @@ package com.flipkart.varadhi.core;
 import com.flipkart.varadhi.entities.*;
 import com.flipkart.varadhi.spi.services.StorageTopicFactory;
 
-import static com.flipkart.varadhi.entities.AbstractTopic.NAME_SEPARATOR;
+import static com.flipkart.varadhi.entities.VaradhiResource.NAME_SEPARATOR;
 
 public class VaradhiTopicFactory {
 

--- a/core/src/main/java/com/flipkart/varadhi/core/VaradhiTopicFactory.java
+++ b/core/src/main/java/com/flipkart/varadhi/core/VaradhiTopicFactory.java
@@ -4,6 +4,8 @@ package com.flipkart.varadhi.core;
 import com.flipkart.varadhi.entities.*;
 import com.flipkart.varadhi.spi.services.StorageTopicFactory;
 
+import static com.flipkart.varadhi.entities.AbstractTopic.NAME_SEPARATOR;
+
 public class VaradhiTopicFactory {
 
     private final StorageTopicFactory<StorageTopic> topicFactory;
@@ -33,7 +35,7 @@ public class VaradhiTopicFactory {
         StorageTopic storageTopic =
                 topicFactory.getTopic(varadhiTopic.getName(), project, capacityPolicy);
         // This is likely to change with replicated topics across zones. To be taken care as part of DR.
-        String internalTopicName = String.join(AbstractTopic.NAME_SEPARATOR, varadhiTopic.getName(), deploymentRegion);
+        String internalTopicName = String.join(NAME_SEPARATOR, varadhiTopic.getName(), deploymentRegion);
         InternalTopic internalTopic = new InternalTopic(
                 internalTopicName,
                 deploymentRegion,

--- a/core/src/test/java/com/flipkart/varadhi/core/VaradhiTopicFactoryTest.java
+++ b/core/src/test/java/com/flipkart/varadhi/core/VaradhiTopicFactoryTest.java
@@ -43,7 +43,7 @@ public class VaradhiTopicFactoryTest {
         );
         VaradhiTopic varadhiTopic = varadhiTopicFactory.get(project, topicResource);
         Assertions.assertNotNull(varadhiTopic);
-        InternalTopic it = varadhiTopic.getProduceTopicForRegion(region).get();
+        InternalTopic it = varadhiTopic.getProduceTopicForRegion(region);
         StorageTopic st = it.getStorageTopic();
         Assertions.assertEquals(it.getTopicState(), TopicState.Producing);
         Assertions.assertEquals(it.getTopicRegion(), region);
@@ -62,7 +62,7 @@ public class VaradhiTopicFactoryTest {
                 null
         );
         VaradhiTopic varadhiTopic = varadhiTopicFactory.get(project, topicResource);
-        InternalTopic it = varadhiTopic.getProduceTopicForRegion(region).get();
+        InternalTopic it = varadhiTopic.getProduceTopicForRegion(region);
         PulsarStorageTopic pt = (PulsarStorageTopic) it.getStorageTopic();
         Assertions.assertEquals(capacityPolicy.getMaxThroughputKBps(), pt.getMaxThroughputKBps());
         Assertions.assertEquals(capacityPolicy.getMaxQPS(), pt.getMaxQPS());

--- a/core/src/test/java/com/flipkart/varadhi/core/VaradhiTopicFactoryTest.java
+++ b/core/src/test/java/com/flipkart/varadhi/core/VaradhiTopicFactoryTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.flipkart.varadhi.Constants.INITIAL_VERSION;
+import static com.flipkart.varadhi.entities.VaradhiResource.INITIAL_VERSION;
 import static org.mockito.Mockito.*;
 
 public class VaradhiTopicFactoryTest {
@@ -43,7 +43,7 @@ public class VaradhiTopicFactoryTest {
         );
         VaradhiTopic varadhiTopic = varadhiTopicFactory.get(project, topicResource);
         Assertions.assertNotNull(varadhiTopic);
-        InternalTopic it = varadhiTopic.getProduceTopicForRegion(region);
+        InternalTopic it = varadhiTopic.getProduceTopicForRegion(region).get();
         StorageTopic st = it.getStorageTopic();
         Assertions.assertEquals(it.getTopicState(), TopicState.Producing);
         Assertions.assertEquals(it.getTopicRegion(), region);
@@ -62,7 +62,7 @@ public class VaradhiTopicFactoryTest {
                 null
         );
         VaradhiTopic varadhiTopic = varadhiTopicFactory.get(project, topicResource);
-        InternalTopic it = varadhiTopic.getProduceTopicForRegion(region);
+        InternalTopic it = varadhiTopic.getProduceTopicForRegion(region).get();
         PulsarStorageTopic pt = (PulsarStorageTopic) it.getStorageTopic();
         Assertions.assertEquals(capacityPolicy.getMaxThroughputKBps(), pt.getMaxThroughputKBps());
         Assertions.assertEquals(capacityPolicy.getMaxQPS(), pt.getMaxQPS());

--- a/core/src/test/java/com/flipkart/varadhi/core/VaradhiTopicServiceTest.java
+++ b/core/src/test/java/com/flipkart/varadhi/core/VaradhiTopicServiceTest.java
@@ -50,7 +50,7 @@ public class VaradhiTopicServiceTest {
         VaradhiTopic varadhiTopic = varadhiTopicFactory.get(project, topicResource);
         varadhiTopicService.create(varadhiTopic);
         verify(metaStore, times(1)).createVaradhiTopic(varadhiTopic);
-        StorageTopic st = varadhiTopic.getProduceTopicForRegion(region).get().getStorageTopic();
+        StorageTopic st = varadhiTopic.getProduceTopicForRegion(region).getStorageTopic();
         verify(storageTopicService, times(1)).create(st);
         verify(storageTopicFactory, times(1)).getTopic(vTopicName, project, capacityPolicy);
     }
@@ -59,7 +59,7 @@ public class VaradhiTopicServiceTest {
     public void createVaradhiTopicWhenMetaStoreFails() {
         TopicResource topicResource = getTopicResource(topicName, project);
         VaradhiTopic varadhiTopic = varadhiTopicFactory.get(project, topicResource);
-        StorageTopic st = varadhiTopic.getProduceTopicForRegion(region).get().getStorageTopic();
+        StorageTopic st = varadhiTopic.getProduceTopicForRegion(region).getStorageTopic();
         doThrow(new VaradhiException("Some error")).when(metaStore).createVaradhiTopic(varadhiTopic);
         Exception exception =
                 Assertions.assertThrows(VaradhiException.class, () -> varadhiTopicService.create(varadhiTopic));
@@ -72,7 +72,7 @@ public class VaradhiTopicServiceTest {
     public void createVaradhiTopicWhenStorageTopicServiceFails() {
         TopicResource topicResource = getTopicResource(topicName, project);
         VaradhiTopic varadhiTopic = varadhiTopicFactory.get(project, topicResource);
-        StorageTopic st = varadhiTopic.getProduceTopicForRegion(region).get().getStorageTopic();
+        StorageTopic st = varadhiTopic.getProduceTopicForRegion(region).getStorageTopic();
         doThrow(new VaradhiException("Some error")).when(storageTopicService).create(st);
         Exception exception =
                 Assertions.assertThrows(VaradhiException.class, () -> varadhiTopicService.create(varadhiTopic));

--- a/core/src/test/java/com/flipkart/varadhi/core/VaradhiTopicServiceTest.java
+++ b/core/src/test/java/com/flipkart/varadhi/core/VaradhiTopicServiceTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static com.flipkart.varadhi.Constants.INITIAL_VERSION;
+import static com.flipkart.varadhi.entities.VaradhiResource.INITIAL_VERSION;
 import static org.mockito.Mockito.*;
 
 public class VaradhiTopicServiceTest {
@@ -50,7 +50,7 @@ public class VaradhiTopicServiceTest {
         VaradhiTopic varadhiTopic = varadhiTopicFactory.get(project, topicResource);
         varadhiTopicService.create(varadhiTopic);
         verify(metaStore, times(1)).createVaradhiTopic(varadhiTopic);
-        StorageTopic st = varadhiTopic.getProduceTopicForRegion(region).getStorageTopic();
+        StorageTopic st = varadhiTopic.getProduceTopicForRegion(region).get().getStorageTopic();
         verify(storageTopicService, times(1)).create(st);
         verify(storageTopicFactory, times(1)).getTopic(vTopicName, project, capacityPolicy);
     }
@@ -59,7 +59,7 @@ public class VaradhiTopicServiceTest {
     public void createVaradhiTopicWhenMetaStoreFails() {
         TopicResource topicResource = getTopicResource(topicName, project);
         VaradhiTopic varadhiTopic = varadhiTopicFactory.get(project, topicResource);
-        StorageTopic st = varadhiTopic.getProduceTopicForRegion(region).getStorageTopic();
+        StorageTopic st = varadhiTopic.getProduceTopicForRegion(region).get().getStorageTopic();
         doThrow(new VaradhiException("Some error")).when(metaStore).createVaradhiTopic(varadhiTopic);
         Exception exception =
                 Assertions.assertThrows(VaradhiException.class, () -> varadhiTopicService.create(varadhiTopic));
@@ -72,7 +72,7 @@ public class VaradhiTopicServiceTest {
     public void createVaradhiTopicWhenStorageTopicServiceFails() {
         TopicResource topicResource = getTopicResource(topicName, project);
         VaradhiTopic varadhiTopic = varadhiTopicFactory.get(project, topicResource);
-        StorageTopic st = varadhiTopic.getProduceTopicForRegion(region).getStorageTopic();
+        StorageTopic st = varadhiTopic.getProduceTopicForRegion(region).get().getStorageTopic();
         doThrow(new VaradhiException("Some error")).when(storageTopicService).create(st);
         Exception exception =
                 Assertions.assertThrows(VaradhiException.class, () -> varadhiTopicService.create(varadhiTopic));

--- a/entities/build.gradle
+++ b/entities/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-annotations:$jackson_version")
     api("jakarta.validation:jakarta.validation-api:$jakarta_version")
 
-    testRuntimeOnly("jakarta.el:jakarta.el-api:4.0.0")
-    testRuntimeOnly("org.glassfish:jakarta.el:4.0.2")
+    testRuntimeOnly("org.glassfish.expressly:expressly:5.0.0")
     testRuntimeOnly("org.hibernate:hibernate-validator:$hibernate_validator_version")
 }

--- a/entities/build.gradle
+++ b/entities/build.gradle
@@ -1,12 +1,11 @@
 plugins {
-    id "com.flipkart.varadhi.java-library-conventions"
+    id "com.flipkart.varadhi.java-published-library-conventions"
 }
 dependencies {
-    implementation(project(":common"))
-    implementation("io.micrometer:micrometer-core")
-    implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("jakarta.validation:jakarta.validation-api")
-    implementation('org.hibernate:hibernate-validator:8.0.1.Final')
-    implementation('org.glassfish.expressly:expressly:5.0.0')
-    testImplementation(project(":pulsar"))
+    api("com.fasterxml.jackson.core:jackson-annotations:$jackson_version")
+    api("jakarta.validation:jakarta.validation-api:$jakarta_version")
+
+    testRuntimeOnly("jakarta.el:jakarta.el-api:4.0.0")
+    testRuntimeOnly("org.glassfish:jakarta.el:4.0.2")
+    testRuntimeOnly("org.hibernate:hibernate-validator:$hibernate_validator_version")
 }

--- a/entities/src/main/java/com/flipkart/varadhi/entities/AbstractTopic.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/AbstractTopic.java
@@ -2,8 +2,6 @@ package com.flipkart.varadhi.entities;
 
 public class AbstractTopic extends VaradhiResource {
 
-    public static String NAME_SEPARATOR = ".";
-
     public AbstractTopic(String name, int version) {
         super(name, version);
     }

--- a/entities/src/main/java/com/flipkart/varadhi/entities/AbstractTopic.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/AbstractTopic.java
@@ -1,6 +1,9 @@
 package com.flipkart.varadhi.entities;
 
 public class AbstractTopic extends VaradhiResource {
+
+    public static String NAME_SEPARATOR = ".";
+
     public AbstractTopic(String name, int version) {
         super(name, version);
     }

--- a/entities/src/main/java/com/flipkart/varadhi/entities/BaseResource.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/BaseResource.java
@@ -1,8 +1,5 @@
 package com.flipkart.varadhi.entities;
 
-import com.flipkart.varadhi.exceptions.ArgumentException;
-import com.flipkart.varadhi.utils.Validator;
-
 import java.util.List;
 
 public interface BaseResource {
@@ -13,6 +10,6 @@ public interface BaseResource {
         if (failures.isEmpty()) {
             return;
         }
-        throw new ArgumentException(String.join(",", failures));
+        throw new IllegalArgumentException(String.join(",", failures));
     }
 }

--- a/entities/src/main/java/com/flipkart/varadhi/entities/Message.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/Message.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 
 import java.util.List;
 
-import static com.flipkart.varadhi.MessageConstants.Headers.MESSAGE_ID;
-
 @Getter
 public class Message {
     private final byte[] payload;
@@ -23,7 +21,7 @@ public class Message {
 
     // TODO:: This will affect json, verify it.
     public String getMessageId() {
-        return getHeader(MESSAGE_ID);
+        return getHeader(StandardHeaders.MESSAGE_ID);
     }
 
     public boolean hasHeader(String key) {

--- a/entities/src/main/java/com/flipkart/varadhi/entities/Org.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/Org.java
@@ -1,6 +1,5 @@
 package com.flipkart.varadhi.entities;
 
-import com.flipkart.varadhi.ValidateVaradhiResource;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 

--- a/entities/src/main/java/com/flipkart/varadhi/entities/Project.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/Project.java
@@ -1,7 +1,6 @@
 package com.flipkart.varadhi.entities;
 
 
-import com.flipkart.varadhi.ValidateVaradhiResource;
 import jakarta.validation.constraints.Size;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/entities/src/main/java/com/flipkart/varadhi/entities/StandardHeaders.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/StandardHeaders.java
@@ -1,0 +1,11 @@
+package com.flipkart.varadhi.entities;
+
+public class StandardHeaders {
+    public static String VARADHI_HEADER_PREFIX = "x_";
+    public static String PRODUCE_TIMESTAMP = "x_restbus_produce_timestamp";
+    public static String PRODUCE_REGION = "x_restbus_produce_region";
+    public static String PRODUCE_IDENTITY = "x_restbus_produce_identity";
+    public static String FORWARDED_FOR = "x-forwarded-for";
+    public static String MESSAGE_ID = "x_restbus_message_id";
+    public static String GROUP_ID = "x_restbus_group_id";
+}

--- a/entities/src/main/java/com/flipkart/varadhi/entities/Team.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/Team.java
@@ -1,6 +1,5 @@
 package com.flipkart.varadhi.entities;
 
-import com.flipkart.varadhi.ValidateVaradhiResource;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/entities/src/main/java/com/flipkart/varadhi/entities/TopicResource.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/TopicResource.java
@@ -1,6 +1,5 @@
 package com.flipkart.varadhi.entities;
 
-import com.flipkart.varadhi.ValidateVaradhiResource;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 

--- a/entities/src/main/java/com/flipkart/varadhi/entities/ValidateVaradhiResource.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/ValidateVaradhiResource.java
@@ -1,4 +1,4 @@
-package com.flipkart.varadhi;
+package com.flipkart.varadhi.entities;
 
 
 import jakarta.validation.Constraint;
@@ -7,7 +7,6 @@ import jakarta.validation.Payload;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static com.flipkart.varadhi.Constants.NAME_VALIDATION_PATTERN;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -15,6 +14,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(TYPE)
 @Retention(RUNTIME)
 public @interface ValidateVaradhiResource {
+
+    String NAME_VALIDATION_PATTERN = "[a-z]{1}[a-z0-9_-]+[a-z0-9]{1}";
+
     String regexp() default NAME_VALIDATION_PATTERN; //set to "" for disabling pattern check.
 
     int min() default 3; //set to -1 for disabling minimum length check. Change default expression as appropriate.

--- a/entities/src/main/java/com/flipkart/varadhi/entities/Validator.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/Validator.java
@@ -1,16 +1,22 @@
-package com.flipkart.varadhi.utils;
+package com.flipkart.varadhi.entities;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
 
 import java.util.List;
 import java.util.Set;
 
 public class Validator {
 
+    /**
+     * TODO: need for customization based on external config.
+     */
+    static final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    static final jakarta.validation.Validator validator = factory.getValidator();
+
     public static <T> List<String> validate(T object) {
-        Set<ConstraintViolation<T>> violations =
-                Validation.buildDefaultValidatorFactory().getValidator().validate(object);
+        Set<ConstraintViolation<T>> violations = validator.validate(object);
         return violations.stream()
                 .map(violation ->
                         violation.getPropertyPath() == null || violation.getPropertyPath().toString().isBlank() ?

--- a/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiResource.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiResource.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @EqualsAndHashCode
 public class VaradhiResource implements BaseResource {
 
-    public static final int INITIAL_VERSION = 1;
+    public static final int INITIAL_VERSION = 0;
     public static final String NAME_SEPARATOR = ".";
 
     private final String name;

--- a/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiResource.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiResource.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 public class VaradhiResource implements BaseResource {
 
     public static final int INITIAL_VERSION = 1;
+    public static final String NAME_SEPARATOR = ".";
 
     private final String name;
 

--- a/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiResource.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiResource.java
@@ -7,6 +7,9 @@ import lombok.Setter;
 @Getter
 @EqualsAndHashCode
 public class VaradhiResource implements BaseResource {
+
+    public static final int INITIAL_VERSION = 1;
+
     private final String name;
 
     @Setter

--- a/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiResourceValidator.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiResourceValidator.java
@@ -1,6 +1,5 @@
-package com.flipkart.varadhi;
+package com.flipkart.varadhi.entities;
 
-import com.flipkart.varadhi.entities.VaradhiResource;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 

--- a/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiTopic.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiTopic.java
@@ -1,17 +1,15 @@
 package com.flipkart.varadhi.entities;
 
-import com.flipkart.varadhi.exceptions.ResourceNotFoundException;
 import lombok.Getter;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static com.flipkart.varadhi.Constants.INITIAL_VERSION;
-import static com.flipkart.varadhi.Constants.NAME_SEPARATOR;
-
+import java.util.Optional;
 
 @Getter
 public class VaradhiTopic extends AbstractTopic {
+
+
     private final Map<String, InternalTopic> internalTopics;
     private final boolean grouped;
 
@@ -43,11 +41,14 @@ public class VaradhiTopic extends AbstractTopic {
         this.internalTopics.put(internalTopic.getTopicRegion(), internalTopic);
     }
 
-    public InternalTopic getProduceTopicForRegion(String region) {
-        InternalTopic internalTopic = internalTopics.get(region);
-        if (null == internalTopic) {
-            throw new ResourceNotFoundException(String.format("Topic not found for region(%s).", region));
-        }
-        return internalTopic;
+    /**
+     * TODO: evaluate whether it should return Optional or not. An unmapped region probably wouldn't be queried.
+     *
+     * @param region
+     *
+     * @return InternalTopic for the given region
+     */
+    public Optional<InternalTopic> getProduceTopicForRegion(String region) {
+        return Optional.ofNullable(internalTopics.get(region));
     }
 }

--- a/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiTopic.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiTopic.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 @Getter
 public class VaradhiTopic extends AbstractTopic {
@@ -48,7 +47,7 @@ public class VaradhiTopic extends AbstractTopic {
      *
      * @return InternalTopic for the given region
      */
-    public Optional<InternalTopic> getProduceTopicForRegion(String region) {
-        return Optional.ofNullable(internalTopics.get(region));
+    public InternalTopic getProduceTopicForRegion(String region) {
+        return internalTopics.get(region);
     }
 }

--- a/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiTopic.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/VaradhiTopic.java
@@ -40,13 +40,6 @@ public class VaradhiTopic extends AbstractTopic {
         this.internalTopics.put(internalTopic.getTopicRegion(), internalTopic);
     }
 
-    /**
-     * TODO: evaluate whether it should return Optional or not. An unmapped region probably wouldn't be queried.
-     *
-     * @param region
-     *
-     * @return InternalTopic for the given region
-     */
     public InternalTopic getProduceTopicForRegion(String region) {
         return internalTopics.get(region);
     }

--- a/entities/src/test/java/com/flipkart/varadhi/ValidateVaradhiResourceTest.java
+++ b/entities/src/test/java/com/flipkart/varadhi/ValidateVaradhiResourceTest.java
@@ -1,7 +1,7 @@
 package com.flipkart.varadhi;
 
+import com.flipkart.varadhi.entities.ValidateVaradhiResource;
 import com.flipkart.varadhi.entities.VaradhiResource;
-import com.flipkart.varadhi.exceptions.ArgumentException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -39,13 +39,13 @@ public class ValidateVaradhiResourceTest {
                         "asdaAsdas", "asdasdasdaasdasdadsadasadadasasdadsad"
                 )
                 .forEach(name -> Assertions.assertThrows(
-                        ArgumentException.class,
+                        IllegalArgumentException.class,
                         () -> new TypeDefault(name, 0).validate(),
                         String.format("TypeDefault Failed for %s", name)
                 ));
 
-        ArgumentException e =
-                Assertions.assertThrows(ArgumentException.class, () -> new TypeMessage("A", 0).validate(),
+        IllegalArgumentException e =
+                Assertions.assertThrows(IllegalArgumentException.class, () -> new TypeMessage("A", 0).validate(),
                         String.format("TypeMessage Failed for name")
                 );
         Assertions.assertEquals("Custom message", e.getMessage());
@@ -62,7 +62,7 @@ public class ValidateVaradhiResourceTest {
                         "a", "aaaaaaaaaaaa"
                 )
                 .forEach(name -> Assertions.assertThrows(
-                        ArgumentException.class,
+                        IllegalArgumentException.class,
                         () -> new TypeMax(name, 0).validate(),
                         String.format("TypeDefault Failed for %s", name)
                 ));

--- a/messaging/src/main/java/com/flipkart/varadhi/produce/ProduceResult.java
+++ b/messaging/src/main/java/com/flipkart/varadhi/produce/ProduceResult.java
@@ -1,7 +1,10 @@
-package com.flipkart.varadhi.entities;
+package com.flipkart.varadhi.produce;
 
 
 import com.flipkart.varadhi.Result;
+import com.flipkart.varadhi.entities.Offset;
+import com.flipkart.varadhi.entities.ProduceStatus;
+import com.flipkart.varadhi.entities.TopicState;
 import com.flipkart.varadhi.exceptions.InvalidStateException;
 import lombok.Getter;
 

--- a/messaging/src/main/java/com/flipkart/varadhi/produce/services/ProducerService.java
+++ b/messaging/src/main/java/com/flipkart/varadhi/produce/services/ProducerService.java
@@ -15,7 +15,6 @@ import com.flipkart.varadhi.spi.services.ProducerFactory;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -79,13 +78,14 @@ public class ProducerService {
     ) {
         try {
             String produceRegion = context.getTopicContext().getRegion();
-            Optional<InternalTopic> opInternalTopic =
+            InternalTopic internalTopic =
                     internalTopicCache.get(varadhiTopicName).getProduceTopicForRegion(produceRegion);
-            if (opInternalTopic.isEmpty()) {
+
+            // TODO: evaluate, if there is no reason for this to be null. It should IllegalStateException if it is null.
+            if (internalTopic == null) {
                 throw new ResourceNotFoundException(String.format("Topic not found for region(%s).", produceRegion));
             }
 
-            InternalTopic internalTopic = opInternalTopic.get();
             if (!internalTopic.getTopicState().isProduceAllowed()) {
                 return CompletableFuture.completedFuture(
                         ProduceResult.ofNonProducingTopic(message.getMessageId(), internalTopic.getTopicState()));

--- a/messaging/src/test/java/com/flipkart/varadhi/services/ProducerServiceTests.java
+++ b/messaging/src/test/java/com/flipkart/varadhi/services/ProducerServiceTests.java
@@ -4,6 +4,7 @@ import com.flipkart.varadhi.core.VaradhiTopicService;
 import com.flipkart.varadhi.entities.*;
 import com.flipkart.varadhi.exceptions.ProduceException;
 import com.flipkart.varadhi.exceptions.ResourceNotFoundException;
+import com.flipkart.varadhi.produce.ProduceResult;
 import com.flipkart.varadhi.produce.config.ProducerOptions;
 import com.flipkart.varadhi.produce.otel.ProducerMetricsImpl;
 import com.flipkart.varadhi.produce.services.ProducerService;
@@ -23,10 +24,9 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 
-import static com.flipkart.varadhi.Constants.NAME_SEPARATOR;
 import static com.flipkart.varadhi.MessageConstants.ANONYMOUS_PRODUCE_IDENTITY;
-import static com.flipkart.varadhi.MessageConstants.Headers.*;
 import static com.flipkart.varadhi.MessageConstants.PRODUCE_CHANNEL_HTTP;
+import static com.flipkart.varadhi.entities.StandardHeaders.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -249,7 +249,7 @@ public class ProducerServiceTests {
 
     public VaradhiTopic getTopic(TopicState state, String name, Project project, String region) {
         VaradhiTopic topic = VaradhiTopic.of(new TopicResource(name, 0, project.getName(), false, null));
-        String itName = String.join(NAME_SEPARATOR, topic.getName(), region);
+        String itName = String.join(AbstractTopic.NAME_SEPARATOR, topic.getName(), region);
         StorageTopic st = new DummyStorageTopic(topic.getName(), 0);
         topic.addInternalTopic(new InternalTopic(itName, region, state, st));
         return topic;

--- a/messaging/src/test/java/com/flipkart/varadhi/services/ProducerServiceTests.java
+++ b/messaging/src/test/java/com/flipkart/varadhi/services/ProducerServiceTests.java
@@ -249,7 +249,7 @@ public class ProducerServiceTests {
 
     public VaradhiTopic getTopic(TopicState state, String name, Project project, String region) {
         VaradhiTopic topic = VaradhiTopic.of(new TopicResource(name, 0, project.getName(), false, null));
-        String itName = String.join(AbstractTopic.NAME_SEPARATOR, topic.getName(), region);
+        String itName = String.join(VaradhiResource.NAME_SEPARATOR, topic.getName(), region);
         StorageTopic st = new DummyStorageTopic(topic.getName(), 0);
         topic.addInternalTopic(new InternalTopic(itName, region, state, st));
         return topic;

--- a/pulsar/src/main/java/com/flipkart/varadhi/pulsar/entities/PulsarOffset.java
+++ b/pulsar/src/main/java/com/flipkart/varadhi/pulsar/entities/PulsarOffset.java
@@ -1,7 +1,6 @@
 package com.flipkart.varadhi.pulsar.entities;
 
 import com.flipkart.varadhi.entities.Offset;
-import com.flipkart.varadhi.exceptions.ArgumentException;
 import org.apache.pulsar.client.api.MessageId;
 
 public class PulsarOffset implements Offset {
@@ -14,12 +13,12 @@ public class PulsarOffset implements Offset {
     @Override
     public int compareTo(Offset o) {
         if (null == o) {
-            throw new ArgumentException("Can not compare null Offset.");
+            throw new IllegalArgumentException("Can not compare null Offset.");
         }
         if (o instanceof PulsarOffset) {
             return messageId.compareTo(((PulsarOffset) o).messageId);
         } else {
-            throw new ArgumentException(String.format(
+            throw new IllegalArgumentException(String.format(
                     "Can not compare different Offset types. Expected Offset is %s, given  %s.",
                     PulsarOffset.class.getName(), o.getClass().getName()
             ));

--- a/pulsar/src/main/java/com/flipkart/varadhi/pulsar/entities/PulsarProducer.java
+++ b/pulsar/src/main/java/com/flipkart/varadhi/pulsar/entities/PulsarProducer.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static com.flipkart.varadhi.Constants.RANDOM_PARTITION_KEY_LENGTH;
-import static com.flipkart.varadhi.MessageConstants.Headers.GROUP_ID;
+import static com.flipkart.varadhi.entities.StandardHeaders.GROUP_ID;
 import static com.flipkart.varadhi.pulsar.Constants.Producer.*;
 import static org.apache.commons.text.CharacterPredicates.DIGITS;
 import static org.apache.commons.text.CharacterPredicates.LETTERS;

--- a/pulsar/src/main/java/com/flipkart/varadhi/pulsar/entities/PulsarStorageTopic.java
+++ b/pulsar/src/main/java/com/flipkart/varadhi/pulsar/entities/PulsarStorageTopic.java
@@ -1,6 +1,5 @@
 package com.flipkart.varadhi.pulsar.entities;
 
-import com.flipkart.varadhi.Constants;
 import com.flipkart.varadhi.entities.CapacityPolicy;
 import com.flipkart.varadhi.entities.StorageTopic;
 import lombok.EqualsAndHashCode;
@@ -26,7 +25,7 @@ public class PulsarStorageTopic extends StorageTopic {
     }
 
     public static PulsarStorageTopic from(String name, CapacityPolicy capacityPolicy) {
-        return new PulsarStorageTopic(name, Constants.INITIAL_VERSION, getPartitionCount(capacityPolicy),
+        return new PulsarStorageTopic(name, INITIAL_VERSION, getPartitionCount(capacityPolicy),
                 capacityPolicy.getMaxQPS(), capacityPolicy.getMaxThroughputKBps()
         );
     }

--- a/pulsar/src/test/java/com/flipkart/varadhi/pulsar/PulsarStackProviderTest.java
+++ b/pulsar/src/test/java/com/flipkart/varadhi/pulsar/PulsarStackProviderTest.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static com.flipkart.varadhi.Constants.INITIAL_VERSION;
+import static com.flipkart.varadhi.entities.VaradhiResource.INITIAL_VERSION;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 

--- a/pulsar/src/test/java/com/flipkart/varadhi/pulsar/entities/PulsarOffsetTest.java
+++ b/pulsar/src/test/java/com/flipkart/varadhi/pulsar/entities/PulsarOffsetTest.java
@@ -1,6 +1,5 @@
 package com.flipkart.varadhi.pulsar.entities;
 
-import com.flipkart.varadhi.exceptions.ArgumentException;
 import com.flipkart.varadhi.spi.services.DummyProducer;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -39,7 +38,7 @@ public class PulsarOffsetTest {
     @Test
     public void NullNotComparable() {
         PulsarOffset p1 = new PulsarOffset(MessageId.earliest);
-        ArgumentException ae = Assertions.assertThrows(ArgumentException.class, () -> p1.compareTo(null));
+        IllegalArgumentException ae = Assertions.assertThrows(IllegalArgumentException.class, () -> p1.compareTo(null));
         Assertions.assertEquals("Can not compare null Offset.", ae.getMessage());
     }
 
@@ -47,7 +46,7 @@ public class PulsarOffsetTest {
     public void CanNotCompareIncompatibleTypes() {
         PulsarOffset p1 = new PulsarOffset(MessageId.earliest);
         DummyProducer.DummyOffset dp1 = new DummyProducer.DummyOffset(1);
-        ArgumentException ae = Assertions.assertThrows(ArgumentException.class, () -> p1.compareTo(dp1));
+        IllegalArgumentException ae = Assertions.assertThrows(IllegalArgumentException.class, () -> p1.compareTo(dp1));
         Assertions.assertEquals(
                 String.format("Can not compare different Offset types. Expected Offset is %s, given  %s.",
                         p1.getClass().getName(), dp1.getClass().getName()

--- a/pulsar/src/test/java/com/flipkart/varadhi/pulsar/entities/PulsarProducerTest.java
+++ b/pulsar/src/test/java/com/flipkart/varadhi/pulsar/entities/PulsarProducerTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static com.flipkart.varadhi.Constants.RANDOM_PARTITION_KEY_LENGTH;
-import static com.flipkart.varadhi.MessageConstants.Headers.GROUP_ID;
+import static com.flipkart.varadhi.entities.StandardHeaders.GROUP_ID;
 import static org.mockito.Mockito.*;
 
 public class PulsarProducerTest {

--- a/server/src/main/java/com/flipkart/varadhi/services/ProjectService.java
+++ b/server/src/main/java/com/flipkart/varadhi/services/ProjectService.java
@@ -2,7 +2,6 @@ package com.flipkart.varadhi.services;
 
 import com.flipkart.varadhi.VaradhiCache;
 import com.flipkart.varadhi.entities.Project;
-import com.flipkart.varadhi.exceptions.ArgumentException;
 import com.flipkart.varadhi.exceptions.InvalidOperationForResourceException;
 import com.flipkart.varadhi.exceptions.ResourceNotFoundException;
 import com.flipkart.varadhi.spi.db.MetaStore;
@@ -50,12 +49,12 @@ public class ProjectService {
     public Project updateProject(Project project) {
         Project existingProject = metaStore.getProject(project.getName());
         if (!project.getOrg().equals(existingProject.getOrg())) {
-            throw new ArgumentException(
+            throw new IllegalArgumentException(
                     String.format("Project(%s) can not be moved across organisation.", project.getName()));
         }
         if (project.getTeam().equals(existingProject.getTeam()) &&
                 project.getDescription().equals(existingProject.getDescription())) {
-            throw new ArgumentException(
+            throw new IllegalArgumentException(
                     String.format(
                             "Project(%s) has same team name and description. Nothing to update.",
                             project.getName()

--- a/server/src/main/java/com/flipkart/varadhi/utils/HeaderUtils.java
+++ b/server/src/main/java/com/flipkart/varadhi/utils/HeaderUtils.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import io.vertx.core.MultiMap;
 
-import static com.flipkart.varadhi.MessageConstants.Headers.VARADHI_HEADER_PREFIX;
+import static com.flipkart.varadhi.entities.StandardHeaders.VARADHI_HEADER_PREFIX;
 
 public class HeaderUtils {
     public static Multimap<String, String> copyVaradhiHeaders(MultiMap headers) {

--- a/server/src/main/java/com/flipkart/varadhi/web/FailureHandler.java
+++ b/server/src/main/java/com/flipkart/varadhi/web/FailureHandler.java
@@ -11,6 +11,8 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.HttpException;
 import lombok.extern.slf4j.Slf4j;
 
+import java.lang.IllegalArgumentException;
+
 import static java.net.HttpURLConnection.*;
 
 @Slf4j
@@ -92,7 +94,7 @@ public class FailureHandler implements Handler<RoutingContext> {
             return HTTP_CONFLICT;
         } else if (ServerNotAvailableException.class == tClazz) {
             return HTTP_UNAVAILABLE;
-        } else if (ArgumentException.class == tClazz) {
+        } else if (IllegalArgumentException.class == tClazz) {
             return HTTP_BAD_REQUEST;
         } else if (ResourceNotFoundException.class == tClazz) {
             return HTTP_NOT_FOUND;

--- a/server/src/main/java/com/flipkart/varadhi/web/v1/admin/TeamHandlers.java
+++ b/server/src/main/java/com/flipkart/varadhi/web/v1/admin/TeamHandlers.java
@@ -3,7 +3,6 @@ package com.flipkart.varadhi.web.v1.admin;
 import com.flipkart.varadhi.auth.PermissionAuthorization;
 import com.flipkart.varadhi.entities.Project;
 import com.flipkart.varadhi.entities.Team;
-import com.flipkart.varadhi.exceptions.ArgumentException;
 import com.flipkart.varadhi.services.TeamService;
 import com.flipkart.varadhi.web.Extensions;
 import com.flipkart.varadhi.web.routes.RouteDefinition;
@@ -113,7 +112,7 @@ public class TeamHandlers implements RouteProvider {
         String orgName = ctx.pathParam(REQUEST_PATH_PARAM_ORG);
         Team team = ctx.body().asValidatedPojo(Team.class);
         if (!orgName.equals(team.getOrg())) {
-            throw new ArgumentException("Specified org name is different from org name in url");
+            throw new IllegalArgumentException("Specified org name is different from org name in url");
         }
 
         Team createdTeam = teamService.createTeam(team);

--- a/server/src/main/java/com/flipkart/varadhi/web/v1/admin/TopicHandlers.java
+++ b/server/src/main/java/com/flipkart/varadhi/web/v1/admin/TopicHandlers.java
@@ -6,7 +6,6 @@ import com.flipkart.varadhi.core.VaradhiTopicService;
 import com.flipkart.varadhi.entities.Project;
 import com.flipkart.varadhi.entities.TopicResource;
 import com.flipkart.varadhi.entities.VaradhiTopic;
-import com.flipkart.varadhi.exceptions.ArgumentException;
 import com.flipkart.varadhi.exceptions.DuplicateResourceException;
 import com.flipkart.varadhi.spi.db.MetaStore;
 import com.flipkart.varadhi.web.Extensions.RequestBodyExtension;
@@ -94,7 +93,7 @@ public class TopicHandlers implements RouteProvider {
         String projectName = ctx.pathParam(REQUEST_PATH_PARAM_PROJECT);
         TopicResource topicResource = ctx.body().asValidatedPojo(TopicResource.class);
         if (!projectName.equals(topicResource.getProject())) {
-            throw new ArgumentException("Specified Project name is different from Project name in url");
+            throw new IllegalArgumentException("Specified Project name is different from Project name in url");
         }
 
         Project project = metaStore.getProject(topicResource.getProject());

--- a/server/src/main/java/com/flipkart/varadhi/web/v1/produce/HeaderValidationHandler.java
+++ b/server/src/main/java/com/flipkart/varadhi/web/v1/produce/HeaderValidationHandler.java
@@ -1,14 +1,13 @@
 package com.flipkart.varadhi.web.v1.produce;
 
 import com.flipkart.varadhi.config.RestOptions;
-import com.flipkart.varadhi.exceptions.ArgumentException;
 import io.vertx.ext.web.RoutingContext;
 
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static com.flipkart.varadhi.MessageConstants.Headers.VARADHI_HEADER_PREFIX;
+import static com.flipkart.varadhi.entities.StandardHeaders.VARADHI_HEADER_PREFIX;
 
 public class HeaderValidationHandler {
     private int headerNameSizeMax;
@@ -29,7 +28,7 @@ public class HeaderValidationHandler {
                 validateEntry(entry);
                 headers.add(key); // multi-value headers are considered one.
                 if (headers.size() >= headersAllowedMax) {
-                    throw new ArgumentException(
+                    throw new IllegalArgumentException(
                             String.format(
                                     "More Varadhi specific headers specified than allowed max(%d).",
                                     headersAllowedMax
@@ -44,10 +43,11 @@ public class HeaderValidationHandler {
 
     private void validateEntry(Map.Entry<String, String> entry) {
         if (entry.getKey().length() > headerNameSizeMax) {
-            throw new ArgumentException(String.format("Header name %s exceeds allowed size.", entry.getKey()));
+            throw new IllegalArgumentException(String.format("Header name %s exceeds allowed size.", entry.getKey()));
         }
         if (entry.getValue().length() > headerValueSizeMax) {
-            throw new ArgumentException(String.format("Value of Header %s exceeds allowed size.", entry.getKey()));
+            throw new IllegalArgumentException(
+                    String.format("Value of Header %s exceeds allowed size.", entry.getKey()));
         }
     }
 }

--- a/server/src/main/java/com/flipkart/varadhi/web/v1/produce/ProduceHandlers.java
+++ b/server/src/main/java/com/flipkart/varadhi/web/v1/produce/ProduceHandlers.java
@@ -3,6 +3,7 @@ package com.flipkart.varadhi.web.v1.produce;
 import com.flipkart.varadhi.auth.PermissionAuthorization;
 import com.flipkart.varadhi.config.RestOptions;
 import com.flipkart.varadhi.entities.*;
+import com.flipkart.varadhi.produce.ProduceResult;
 import com.flipkart.varadhi.produce.services.ProducerService;
 import com.flipkart.varadhi.services.ProjectService;
 import com.flipkart.varadhi.utils.HeaderUtils;
@@ -32,9 +33,9 @@ import static com.flipkart.varadhi.Constants.HttpCodes.HTTP_UNPROCESSABLE_ENTITY
 import static com.flipkart.varadhi.Constants.PathParams.REQUEST_PATH_PARAM_PROJECT;
 import static com.flipkart.varadhi.Constants.PathParams.REQUEST_PATH_PARAM_TOPIC;
 import static com.flipkart.varadhi.MessageConstants.ANONYMOUS_PRODUCE_IDENTITY;
-import static com.flipkart.varadhi.MessageConstants.Headers.*;
 import static com.flipkart.varadhi.MessageConstants.PRODUCE_CHANNEL_HTTP;
 import static com.flipkart.varadhi.entities.ResourceAction.TOPIC_PRODUCE;
+import static com.flipkart.varadhi.entities.StandardHeaders.*;
 import static com.flipkart.varadhi.web.routes.RouteBehaviour.authenticated;
 import static com.flipkart.varadhi.web.routes.RouteBehaviour.hasBody;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;

--- a/server/src/test/java/com/flipkart/varadhi/services/ProjectServiceTest.java
+++ b/server/src/test/java/com/flipkart/varadhi/services/ProjectServiceTest.java
@@ -4,7 +4,6 @@ import com.flipkart.varadhi.db.VaradhiMetaStore;
 import com.flipkart.varadhi.entities.Org;
 import com.flipkart.varadhi.entities.Project;
 import com.flipkart.varadhi.entities.Team;
-import com.flipkart.varadhi.exceptions.ArgumentException;
 import com.flipkart.varadhi.exceptions.DuplicateResourceException;
 import com.flipkart.varadhi.exceptions.InvalidOperationForResourceException;
 import com.flipkart.varadhi.exceptions.ResourceNotFoundException;
@@ -162,7 +161,7 @@ public class ProjectServiceTest {
         String argumentErr =
                 String.format("Project(%s) has same team name and description. Nothing to update.", pLatest.getName());
         validateException(
-                argumentErr, ArgumentException.class,
+                argumentErr, IllegalArgumentException.class,
                 () -> projectService.updateProject(pLatest)
         );
 
@@ -174,7 +173,7 @@ public class ProjectServiceTest {
 
         argumentErr = String.format("Project(%s) can not be moved across organisation.", orgUpdate.getName());
         validateException(
-                argumentErr, ArgumentException.class,
+                argumentErr, IllegalArgumentException.class,
                 () -> projectService.updateProject(orgUpdate)
         );
     }

--- a/server/src/test/java/com/flipkart/varadhi/web/admin/ProjectHandlersTest.java
+++ b/server/src/test/java/com/flipkart/varadhi/web/admin/ProjectHandlersTest.java
@@ -3,7 +3,10 @@ package com.flipkart.varadhi.web.admin;
 import com.flipkart.varadhi.entities.Org;
 import com.flipkart.varadhi.entities.Project;
 import com.flipkart.varadhi.entities.Team;
-import com.flipkart.varadhi.exceptions.*;
+import com.flipkart.varadhi.exceptions.DuplicateResourceException;
+import com.flipkart.varadhi.exceptions.InvalidOperationForResourceException;
+import com.flipkart.varadhi.exceptions.MetaStoreException;
+import com.flipkart.varadhi.exceptions.ResourceNotFoundException;
 import com.flipkart.varadhi.services.ProjectService;
 import com.flipkart.varadhi.web.ErrorResponse;
 import com.flipkart.varadhi.web.WebTestBase;
@@ -121,7 +124,7 @@ public class ProjectHandlersTest extends WebTestBase {
         Assertions.assertEquals(p1, p1Updated);
 
         String argumentError = String.format("Project(%s) can not be moved across organisation.", p1.getName());
-        doThrow(new ArgumentException(argumentError)).when(projectService).updateProject(p1);
+        doThrow(new IllegalArgumentException(argumentError)).when(projectService).updateProject(p1);
         ErrorResponse response = sendRequestWithBody(request, p1, 400, argumentError, ErrorResponse.class);
         Assertions.assertEquals(argumentError, response.reason());
 

--- a/server/src/test/java/com/flipkart/varadhi/web/produce/BodyHandlerTest.java
+++ b/server/src/test/java/com/flipkart/varadhi/web/produce/BodyHandlerTest.java
@@ -1,7 +1,7 @@
 package com.flipkart.varadhi.web.produce;
 
 import com.flipkart.varadhi.Result;
-import com.flipkart.varadhi.entities.ProduceResult;
+import com.flipkart.varadhi.produce.ProduceResult;
 import com.flipkart.varadhi.spi.services.DummyProducer;
 import com.flipkart.varadhi.web.ErrorResponse;
 import io.vertx.core.buffer.Buffer;
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 
-import static com.flipkart.varadhi.MessageConstants.Headers.FORWARDED_FOR;
-import static com.flipkart.varadhi.MessageConstants.Headers.MESSAGE_ID;
+import static com.flipkart.varadhi.entities.StandardHeaders.FORWARDED_FOR;
+import static com.flipkart.varadhi.entities.StandardHeaders.MESSAGE_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 

--- a/server/src/test/java/com/flipkart/varadhi/web/produce/HeaderValidationTest.java
+++ b/server/src/test/java/com/flipkart/varadhi/web/produce/HeaderValidationTest.java
@@ -2,7 +2,7 @@ package com.flipkart.varadhi.web.produce;
 
 import com.flipkart.varadhi.Result;
 import com.flipkart.varadhi.config.RestOptions;
-import com.flipkart.varadhi.entities.ProduceResult;
+import com.flipkart.varadhi.produce.ProduceResult;
 import com.flipkart.varadhi.spi.services.DummyProducer;
 import com.flipkart.varadhi.web.ErrorResponse;
 import com.flipkart.varadhi.web.v1.produce.HeaderValidationHandler;
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static com.flipkart.varadhi.MessageConstants.Headers.FORWARDED_FOR;
-import static com.flipkart.varadhi.MessageConstants.Headers.MESSAGE_ID;
+import static com.flipkart.varadhi.entities.StandardHeaders.FORWARDED_FOR;
+import static com.flipkart.varadhi.entities.StandardHeaders.MESSAGE_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 

--- a/server/src/test/java/com/flipkart/varadhi/web/produce/ProduceHandlersTest.java
+++ b/server/src/test/java/com/flipkart/varadhi/web/produce/ProduceHandlersTest.java
@@ -2,10 +2,10 @@ package com.flipkart.varadhi.web.produce;
 
 import com.flipkart.varadhi.Result;
 import com.flipkart.varadhi.entities.Message;
-import com.flipkart.varadhi.entities.ProduceResult;
 import com.flipkart.varadhi.entities.TopicState;
 import com.flipkart.varadhi.exceptions.ProduceException;
 import com.flipkart.varadhi.exceptions.ResourceNotFoundException;
+import com.flipkart.varadhi.produce.ProduceResult;
 import com.flipkart.varadhi.spi.services.DummyProducer;
 import com.flipkart.varadhi.web.ErrorResponse;
 import io.vertx.core.MultiMap;
@@ -22,8 +22,10 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static com.flipkart.varadhi.MessageConstants.ANONYMOUS_PRODUCE_IDENTITY;
-import static com.flipkart.varadhi.MessageConstants.Headers.*;
+import static com.flipkart.varadhi.MessageConstants.Headers.REQUIRED_HEADERS;
 import static com.flipkart.varadhi.MessageConstants.PRODUCE_CHANNEL_HTTP;
+import static com.flipkart.varadhi.entities.StandardHeaders.FORWARDED_FOR;
+import static com.flipkart.varadhi.entities.StandardHeaders.MESSAGE_ID;
 import static com.flipkart.varadhi.entities.TopicState.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;

--- a/server/src/testE2E/java/com/flipkart/varadhi/TopicTests.java
+++ b/server/src/testE2E/java/com/flipkart/varadhi/TopicTests.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static com.flipkart.varadhi.entities.VaradhiResource.INITIAL_VERSION;
+
 public class TopicTests extends E2EBase {
 
     private static final String VaradhiBaseUri = "http://localhost:8080";
@@ -42,7 +44,7 @@ public class TopicTests extends E2EBase {
     public void createTopic() {
         String topicName = "test-topic-1";
         TopicResource topic =
-                new TopicResource(topicName, Constants.INITIAL_VERSION, o1t1Project1.getName(), false, null);
+                new TopicResource(topicName, INITIAL_VERSION, o1t1Project1.getName(), false, null);
         TopicResource r = makeCreateRequest(getTopicsUri(o1t1Project1), topic, 200);
         Assertions.assertEquals(topic.getVersion(), r.getVersion());
         Assertions.assertEquals(topic.getName(), r.getName());
@@ -62,7 +64,7 @@ public class TopicTests extends E2EBase {
     public void createTopicWithValidationFailure() {
         String topicName = "ab";
         TopicResource topic =
-                new TopicResource(topicName, Constants.INITIAL_VERSION, o1t1Project1.getName(), false, null);
+                new TopicResource(topicName, INITIAL_VERSION, o1t1Project1.getName(), false, null);
         String errorValidationTopic = "Invalid Topic name. Check naming constraints.";
         makeCreateRequest(getTopicsUri(o1t1Project1), topic, 400, errorValidationTopic, true);
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,5 +8,5 @@
  */
 
 rootProject.name = 'varadhi'
-include('common', 'entities', 'core', 'messaging', 'pulsar', 'server', 'authz')
+include('entities', 'common', 'core', 'messaging', 'pulsar', 'server', 'authz', 'consumer')
 


### PR DESCRIPTION
- Cleaned up dependencies. 
- Entities will be api dependency for other modules.
- Common module now depends on entities. Earlier it was opposite.
- Entities now only explicitly depends on jackson-annotations, jakarta-api as api dependency.
- Moved some of the constants to the core related classes. initial_version -> base resource. name_delimiter to AbstractTopic.
- Removed exception classes which are duplicate of standard java exceptions.

Resolves #62