### PR TITLE
Adding subscription related entities.

### DIFF
--- a/buildSrc/src/main/groovy/com.flipkart.varadhi.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.flipkart.varadhi.java-common-conventions.gradle
@@ -17,7 +17,6 @@ repositories {
 ext {
     lombok_version = "1.18.26"
     slf4j_version = "2.0.7"
-    javax_version = "1.3.2"
     vertx_version = "4.4.4"
 
     otl_version = "1.25.0"
@@ -27,7 +26,8 @@ ext {
     guava_version = "32.1.1-jre"
     curator_version = "5.5.0"
     jackson_version = "2.15.1"
-    jakarta_version = "3.0.2"
+    jakarta_validation_version = "3.0.2"
+    jakarta_ws_version = "3.1.0"
     commons_lang_version = "3.11"
 
     hibernate_validator_version = "8.0.1.Final"
@@ -88,7 +88,7 @@ dependencies {
         implementation("io.micrometer:micrometer-registry-jmx:$micrometer_version")
         implementation("com.google.guava:guava:$guava_version")
 
-        implementation("jakarta.validation:jakarta.validation-api:$jakarta_version")
+        implementation("jakarta.validation:jakarta.validation-api:$jakarta_validation_version")
 
         testCompileOnly("org.projectlombok:lombok:$lombok_version")
         testAnnotationProcessor("org.projectlombok:lombok:$lombok_version")

--- a/entities/build.gradle
+++ b/entities/build.gradle
@@ -3,7 +3,8 @@ plugins {
 }
 dependencies {
     api("com.fasterxml.jackson.core:jackson-annotations:$jackson_version")
-    api("jakarta.validation:jakarta.validation-api:$jakarta_version")
+    api("jakarta.validation:jakarta.validation-api:$jakarta_validation_version")
+    api("jakarta.ws.rs:jakarta.ws.rs-api:$jakarta_ws_version")
 
     testRuntimeOnly("org.glassfish.expressly:expressly:5.0.0")
     testRuntimeOnly("org.hibernate:hibernate-validator:$hibernate_validator_version")

--- a/entities/src/main/java/com/flipkart/varadhi/entities/CodeRange.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/CodeRange.java
@@ -1,0 +1,17 @@
+package com.flipkart.varadhi.entities;
+
+import lombok.Data;
+
+/**
+ * CodeRange for some kind of codes.
+ * from and to are inclusive bounds
+ */
+@Data
+public class CodeRange {
+    private final int from;
+    private final int to;
+
+    public boolean inRange(final int code) {
+        return code >= from && code <= to;
+    }
+}

--- a/entities/src/main/java/com/flipkart/varadhi/entities/ConsumptionPolicy.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/ConsumptionPolicy.java
@@ -1,0 +1,24 @@
+package com.flipkart.varadhi.entities;
+
+import lombok.Data;
+
+@Data
+public class ConsumptionPolicy {
+    private final int maxParallelism;
+
+    /**
+     * Proportion of the parallelism that is allocated for delivery of failed messages.
+     */
+    private final double maxRecoveryAllocation;
+
+    /**
+     * true if recovering dlt is preferred over retryable errors.
+     */
+    private final boolean dltRecoveryPreferred;
+
+    /**
+     * In terms of proportion of consumption rate over some time window. Between 0 and 1.
+     */
+    private final double maxErrorThreshold;
+    private final ThrottleSpec throttleSpec;
+}

--- a/entities/src/main/java/com/flipkart/varadhi/entities/Endpoint.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/Endpoint.java
@@ -1,0 +1,32 @@
+package com.flipkart.varadhi.entities;
+
+import jakarta.ws.rs.HttpMethod;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.net.URL;
+
+public abstract sealed class Endpoint {
+
+    abstract Protocol getProtocol();
+
+    @EqualsAndHashCode(callSuper = true)
+    @Data
+    public static final class HttpEndpoint extends Endpoint {
+        private final URL url;
+        private final HttpMethod method;
+        private final String contentType;
+
+        private final boolean http2Supported;
+
+        @Override
+        Protocol getProtocol() {
+            return http2Supported ? Protocol.HTTP2 : Protocol.HTTP1_1;
+        }
+    }
+
+    public enum Protocol {
+        HTTP1_1,
+        HTTP2,
+    }
+}

--- a/entities/src/main/java/com/flipkart/varadhi/entities/InternalTopic.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/InternalTopic.java
@@ -6,21 +6,8 @@ import lombok.Data;
 @Data
 public class InternalTopic {
 
-    private String topicRegion;
-    private TopicState topicState;
-    private String name;
-    private StorageTopic storageTopic;
-
-    public InternalTopic(
-            String name,
-            String topicRegion,
-            TopicState topicState,
-            StorageTopic storageTopic
-    ) {
-        this.name = name;
-        this.topicRegion = topicRegion;
-        this.topicState = topicState;
-        this.storageTopic = storageTopic;
-    }
-
+    private final String name;
+    private final String topicRegion;
+    private final TopicState topicState;
+    private final StorageTopic storageTopic;
 }

--- a/entities/src/main/java/com/flipkart/varadhi/entities/Offset.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/Offset.java
@@ -2,11 +2,10 @@ package com.flipkart.varadhi.entities;
 
 import java.io.Serializable;
 
-/*
- Offset of the message in the topic.
- Details are messaging stack specific.
+/**
+ * Offset of the message in the topic.
+ * Details are messaging stack specific.
  */
-
 public interface Offset extends Comparable<Offset>, Serializable {
 
 }

--- a/entities/src/main/java/com/flipkart/varadhi/entities/Org.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/Org.java
@@ -8,10 +8,7 @@ import lombok.Value;
 @ValidateVaradhiResource(message = "Invalid Org name. Check naming constraints.")
 public class Org extends VaradhiResource {
 
-    public Org(
-            String name,
-            int version
-    ) {
+    public Org(String name, int version) {
         super(name, version);
     }
 }

--- a/entities/src/main/java/com/flipkart/varadhi/entities/RetentionPolicy.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/RetentionPolicy.java
@@ -1,0 +1,9 @@
+package com.flipkart.varadhi.entities;
+
+import lombok.Data;
+
+@Data
+public class RetentionPolicy {
+
+    private final int hours;
+}

--- a/entities/src/main/java/com/flipkart/varadhi/entities/RetryPolicy.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/RetryPolicy.java
@@ -1,0 +1,18 @@
+package com.flipkart.varadhi.entities;
+
+import lombok.Data;
+
+@Data
+public class RetryPolicy {
+    private final CodeRange[] retryCodes;
+    private final BackoffType backoffType;
+    private final int minBackoff;
+    private final int maxBackoff;
+    private final int multiplier;
+    private final int retryAttempts;
+
+    public enum BackoffType {
+        LINEAR,
+        EXPONENTIAL
+    }
+}

--- a/entities/src/main/java/com/flipkart/varadhi/entities/Subscription.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/Subscription.java
@@ -1,0 +1,23 @@
+package com.flipkart.varadhi.entities;
+
+import jakarta.validation.constraints.NotNull;
+
+public class Subscription extends VaradhiResource {
+    @NotNull
+    private String topic;
+    private boolean grouped;
+
+    @NotNull
+    private Endpoint endpoint;
+
+    // TODO: add other policies here
+
+    public Subscription(
+            String name, int version, String topic, boolean grouped, Endpoint endpoint
+    ) {
+        super(name, version);
+        this.topic = topic;
+        this.grouped = grouped;
+        this.endpoint = endpoint;
+    }
+}

--- a/entities/src/main/java/com/flipkart/varadhi/entities/ThrottleSpec.java
+++ b/entities/src/main/java/com/flipkart/varadhi/entities/ThrottleSpec.java
@@ -1,0 +1,11 @@
+package com.flipkart.varadhi.entities;
+
+import lombok.Data;
+
+@Data
+public class ThrottleSpec {
+    private final double factor;
+    private final int waitSeconds;
+    private final int pingSeconds;
+    private final int stopAfterSeconds;
+}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation("org.apache.commons:commons-lang3")
 
     implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("javax.annotation:javax.annotation-api:$javax_version")
 
     implementation("io.vertx:vertx-core")
     implementation("io.vertx:vertx-config")


### PR DESCRIPTION
resolves #63.

So I have noticed few things and I would like to place some guidelines in how we are going to define entities.

* The entities module is for entities that will be included in our "apis". Since varadhi will have a lot of pluggables, via spi, the service provider entities are also part of the api. The entities in the http layer is also part of the api.
* We may define multiple classes which may be related to one core entity, for eg: a subscription. But these classes needs to be part of some api for it to be in entity module. We will still try to reduce such multiplicity / duplications.
* 2 main candidates for apis are storage layer & web layer. We can expect 2 classes (at most) for any entity for the mentioned apis.
* Entities for storage layer should be lean and free of redundancy & complexity. Dont have nullable fields if possible.
* Entities for rest-layer needs to be rest api centric. i.e. We can think of not having uber updateSubscription api, and instead have targeted apis. updateConsumptionPolicy() api. updateEndpoint() api.. and so on. We may choose to use same pojo for at rest layer & storage layer, if the pojo is fundamental in nature. But having a rest specific entities may be more flexible, as we can have nullable fields there.
* Entities only required internally in other modules can be in their respective modules.