### PR TITLE
Initial implementation for Grouped and UnGrouped Message Source

### DIFF
--- a/consumer/build.gradle
+++ b/consumer/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     api("jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version")
     implementation("org.slf4j:slf4j-api:$slf4j_version")
     implementation("org.jctools:jctools-core:$jctools_version")
+    implementation("org.apache.commons:commons-lang3")
 
     testImplementation(testFixtures(project(':common')))
     testImplementation(testFixtures(project(":spi")))

--- a/consumer/build.gradle
+++ b/consumer/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation("org.jctools:jctools-core:$jctools_version")
 
     testImplementation(testFixtures(project(':common')))
+    testImplementation(testFixtures(project(":spi")))
     testImplementation("org.junit.jupiter:junit-jupiter:$junit_version")
     testImplementation("org.mockito:mockito-junit-jupiter:$mockito_version")
     testImplementation("org.awaitility:awaitility:$awaitility_version")

--- a/consumer/src/main/java/com/flipkart/varadhi/consumer/GroupedMessageSrc.java
+++ b/consumer/src/main/java/com/flipkart/varadhi/consumer/GroupedMessageSrc.java
@@ -1,0 +1,160 @@
+package com.flipkart.varadhi.consumer;
+
+import com.flipkart.varadhi.entities.Message;
+import com.flipkart.varadhi.entities.Offset;
+import com.flipkart.varadhi.spi.services.Consumer;
+import com.flipkart.varadhi.spi.services.PolledMessage;
+import com.flipkart.varadhi.spi.services.PolledMessages;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableBoolean;
+
+import java.util.*;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicLong;
+
+@RequiredArgsConstructor
+public class GroupedMessageSrc<O extends Offset> implements MessageSrc {
+
+    private final ConcurrentHashMap<String, GroupTracker> allGroupedMessages = new ConcurrentHashMap<>();
+    private final BlockingDeque<String> freeGroups = new LinkedBlockingDeque<>();
+    private final AtomicLong totalInFlightMessages = new AtomicLong(0);
+    private final long maxInFlightMessages = 100; // todo: make configurable
+
+    private final Consumer<O> consumer;
+
+    @Override
+    public CompletableFuture<Integer> nextMessages(MessageTracker[] messages) {
+        if (hasMaxInFlightMessages()) {
+            return replenishAvailableGroups().thenApply(v -> nextMessagesInternal(messages));
+        }
+        return CompletableFuture.supplyAsync(() -> nextMessagesInternal(messages));
+    }
+
+    private int nextMessagesInternal(MessageTracker[] messages) {
+        GroupTracker groupTracker = getGroupTracker();
+        if (null == groupTracker) {
+            return 0;
+        }
+
+        MessageTracker messageTracker = groupTracker.messages.getFirst().nextMessage();
+        messages[0] = new GroupedMessageTracker(messageTracker);
+        return 1;
+    }
+
+    private GroupTracker getGroupTracker() {
+        String freeGroup = freeGroups.poll();
+        if (freeGroup == null) {
+            return null;
+        }
+
+        GroupTracker tracker = allGroupedMessages.get(freeGroup);
+        if (tracker == null || tracker.status == GroupStatus.IN_FLIGHT) {
+            throw new IllegalStateException(String.format("Polled group %s: %s", freeGroup, tracker));
+        }
+
+        tracker.status = GroupStatus.IN_FLIGHT;
+        return tracker;
+    }
+
+    private CompletableFuture<Void> replenishAvailableGroups() {
+        return consumer.receiveAsync().thenApply(polledMessages -> {
+            replenishAvailableGroups(polledMessages);
+            return null;
+        });
+    }
+
+    private void replenishAvailableGroups(PolledMessages<O> polledMessages) {
+        Map<String, List<MessageTracker>> groupedMessages = groupMessagesByGroupId(polledMessages);
+        for (Map.Entry<String, List<MessageTracker>> group : groupedMessages.entrySet()) {
+            MessageBatch newBatch = new MessageBatch(group.getValue());
+            MutableBoolean isNewGroup = new MutableBoolean(false);
+            allGroupedMessages.compute(group.getKey(), (groupId, tracker) -> {
+                if (tracker == null) {
+                    tracker = new GroupTracker();
+                    isNewGroup.setTrue();
+                }
+                tracker.messages.add(newBatch);
+                return tracker;
+            });
+            totalInFlightMessages.addAndGet(newBatch.count());
+            if (isNewGroup.isTrue()) {
+                freeGroups.add(group.getKey());
+            }
+        }
+    }
+
+    private Map<String, List<MessageTracker>> groupMessagesByGroupId(PolledMessages<O> polledMessages) {
+        Map<String, List<MessageTracker>> groups = new HashMap<>();
+        for (PolledMessage<O> polledMessage : polledMessages) {
+            MessageTracker messageTracker = new PolledMessageTracker<>(consumer, polledMessage);
+            String groupId = messageTracker.getGroupId();
+            if (StringUtils.isBlank(groupId)) {
+                throw new IllegalStateException("Group id not found for message " + messageTracker.getMessage());
+            }
+            groups.computeIfAbsent(groupId, list -> new ArrayList<>()).add(messageTracker);
+        }
+        return groups;
+    }
+
+    private boolean hasMaxInFlightMessages() {
+        return totalInFlightMessages.get() >= maxInFlightMessages;
+    }
+
+    enum GroupStatus {
+        FREE,
+        IN_FLIGHT
+    }
+
+    static class GroupTracker {
+        GroupStatus status = GroupStatus.FREE;
+
+        LinkedList<MessageBatch> messages = new LinkedList<>();
+    }
+
+    @AllArgsConstructor
+    private class GroupedMessageTracker implements MessageTracker {
+        private final MessageTracker messageTracker;
+
+        @Override
+        public Message getMessage() {
+            return messageTracker.getMessage();
+        }
+
+        @Override
+        public void onConsumed(MessageConsumptionStatus status) {
+            messageTracker.onConsumed(status);
+            String groupId = getGroupId();
+            free(groupId, status);
+        }
+
+        private void free(String groupId, MessageConsumptionStatus status) {
+            MutableBoolean isRemaining = new MutableBoolean(false);
+            allGroupedMessages.compute(groupId, (gId, tracker) -> {
+                if (tracker == null || tracker.status == GroupStatus.FREE) {
+                    throw new IllegalStateException(String.format("Tried to free group %s: %s", gId, tracker));
+                }
+                // todo: update group consumption status in tracker?
+                var messages = tracker.messages;
+                if (!messages.isEmpty() && messages.getFirst().remaining() == 0) {
+                    messages.removeFirst();
+                }
+                if (!messages.isEmpty()) {
+                    tracker.status = GroupStatus.FREE;
+                    isRemaining.setTrue();
+                    return tracker;
+                } else {
+                    return null;
+                }
+            });
+            totalInFlightMessages.decrementAndGet();
+            if (isRemaining.isTrue()) {
+                freeGroups.addFirst(groupId);
+            }
+        }
+    }
+}

--- a/consumer/src/main/java/com/flipkart/varadhi/consumer/GroupedMessageSrc.java
+++ b/consumer/src/main/java/com/flipkart/varadhi/consumer/GroupedMessageSrc.java
@@ -122,7 +122,10 @@ public class GroupedMessageSrc<O extends Offset> implements MessageSrc {
     }
 
     enum GroupStatus {
+        // no message for this group is in active processing by the consumer
         FREE,
+
+        // at least one message for this group is in active processing by the consumer
         IN_FLIGHT
     }
 

--- a/consumer/src/main/java/com/flipkart/varadhi/consumer/MessageBatch.java
+++ b/consumer/src/main/java/com/flipkart/varadhi/consumer/MessageBatch.java
@@ -1,0 +1,33 @@
+package com.flipkart.varadhi.consumer;
+
+import java.util.List;
+
+public class MessageBatch {
+    private final List<MessageTracker> messages;
+    private int offset;
+
+    public MessageBatch(List<MessageTracker> messages) {
+        if (messages.isEmpty()) {
+            throw new IllegalArgumentException("Creating message batch without any messages");
+        }
+        this.messages = messages;
+        this.offset = 0;
+    }
+
+    MessageTracker nextMessage() {
+        if (offset < messages.size()) {
+            MessageTracker messageTracker = messages.get(offset);
+            messages.set(offset++, null);
+            return messageTracker;
+        }
+        throw new IllegalStateException("End of batch reached, nothing to consume");
+    }
+
+    public int remaining() {
+        return messages.size() - offset;
+    }
+
+    public int count() {
+        return messages.size();
+    }
+}

--- a/consumer/src/main/java/com/flipkart/varadhi/consumer/PolledMessageTracker.java
+++ b/consumer/src/main/java/com/flipkart/varadhi/consumer/PolledMessageTracker.java
@@ -22,14 +22,13 @@ public class PolledMessageTracker<O extends Offset> implements MessageTracker {
 
     @Override
     public void onConsumed(MessageConsumptionStatus status) {
-        if (status == MessageConsumptionStatus.SENT || status == MessageConsumptionStatus.FILTERED) {
-            committer.commitIndividualAsync(message);
-        }
+        committer.commitIndividualAsync(message);
     }
 
-    // TODO(aayush): dummy class for poc
+    // TODO(aayush): come up with better modeling of message and message with offset
     static class PolledMessageWrapper<O extends Offset> extends Message {
         PolledMessage<O> polledMessage;
+        // keeping headers as properties and outside the payload
 
         public PolledMessageWrapper(PolledMessage<O> polledMessage) {
             super(polledMessage.getPayload(), ArrayListMultimap.create());

--- a/consumer/src/main/java/com/flipkart/varadhi/consumer/PolledMessageTracker.java
+++ b/consumer/src/main/java/com/flipkart/varadhi/consumer/PolledMessageTracker.java
@@ -6,6 +6,9 @@ import com.flipkart.varadhi.spi.services.Consumer;
 import com.flipkart.varadhi.spi.services.PolledMessage;
 import com.google.common.collect.ArrayListMultimap;
 
+/**
+ * Message tracking implementation for PolledMessage type.
+ */
 public class PolledMessageTracker<O extends Offset> implements MessageTracker {
     private final PolledMessage<O> message;
     private final Consumer<O> committer;

--- a/consumer/src/main/java/com/flipkart/varadhi/consumer/PolledMessageTracker.java
+++ b/consumer/src/main/java/com/flipkart/varadhi/consumer/PolledMessageTracker.java
@@ -4,25 +4,36 @@ import com.flipkart.varadhi.entities.Message;
 import com.flipkart.varadhi.entities.Offset;
 import com.flipkart.varadhi.spi.services.Consumer;
 import com.flipkart.varadhi.spi.services.PolledMessage;
+import com.google.common.collect.ArrayListMultimap;
 
-public class UnGroupedMessageTracker<O extends Offset> implements MessageTracker {
+public class PolledMessageTracker<O extends Offset> implements MessageTracker {
     private final PolledMessage<O> message;
     private final Consumer<O> committer;
 
-    public UnGroupedMessageTracker(Consumer<O> committer, PolledMessage<O> message) {
+    public PolledMessageTracker(Consumer<O> committer, PolledMessage<O> message) {
         this.message = message;
         this.committer = committer;
     }
 
     @Override
     public Message getMessage() {
-        return new UnGroupedMessageSrc.PolledMessageWrapper<>(message);
+        return new PolledMessageWrapper<>(message);
     }
 
     @Override
     public void onConsumed(MessageConsumptionStatus status) {
         if (status == MessageConsumptionStatus.SENT || status == MessageConsumptionStatus.FILTERED) {
             committer.commitIndividualAsync(message);
+        }
+    }
+
+    // TODO(aayush): dummy class for poc
+    static class PolledMessageWrapper<O extends Offset> extends Message {
+        PolledMessage<O> polledMessage;
+
+        public PolledMessageWrapper(PolledMessage<O> polledMessage) {
+            super(polledMessage.getPayload(), ArrayListMultimap.create());
+            this.polledMessage = polledMessage;
         }
     }
 }

--- a/consumer/src/main/java/com/flipkart/varadhi/consumer/UnGroupedMessageSrc.java
+++ b/consumer/src/main/java/com/flipkart/varadhi/consumer/UnGroupedMessageSrc.java
@@ -1,0 +1,83 @@
+package com.flipkart.varadhi.consumer;
+
+import com.flipkart.varadhi.entities.Message;
+import com.flipkart.varadhi.entities.Offset;
+import com.flipkart.varadhi.spi.services.Consumer;
+import com.flipkart.varadhi.spi.services.PolledMessage;
+import com.flipkart.varadhi.spi.services.PolledMessages;
+import lombok.RequiredArgsConstructor;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+
+@RequiredArgsConstructor
+public class UnGroupedMessageSrc<O extends Offset> implements MessageSrc {
+
+    final Consumer<O> consumer;
+
+    private final BlockingQueue<MessageTracker> buffer = new LinkedBlockingQueue<>();
+
+    @Override
+    public CompletableFuture<Integer> nextMessages(MessageTracker[] messages) {
+        if (buffer.isEmpty()) {
+            return consumer.receiveAsync().thenApply(polledMessages -> processPolledMessages(polledMessages, messages));
+        } else {
+            return CompletableFuture.completedFuture(processBuffer(messages));
+        }
+    }
+
+    private int processPolledMessages(PolledMessages<O> polledMessages, MessageTracker[] messages) {
+        int i = 0;
+        for (PolledMessage<O> polledMessage : polledMessages) {
+            MessageTracker messageTracker = new MessageTrackerImpl<>(polledMessage, consumer);
+            if (i == messages.length) {
+                buffer.add(messageTracker);
+            } else {
+                messages[i++] = messageTracker;
+            }
+        }
+        return i;
+    }
+
+    private int processBuffer(MessageTracker[] messages) {
+        int i = 0;
+        while (i < messages.length && !buffer.isEmpty()) {
+            messages[i++] = buffer.poll();
+        }
+        return i;
+    }
+
+    // dummy impl for poc
+    static class MessageTrackerImpl<O extends Offset> implements MessageTracker {
+        private final PolledMessage<O> message;
+        private final Consumer<O> consumer;
+
+        public MessageTrackerImpl(PolledMessage<O> message, Consumer<O> consumer) {
+            this.message = message;
+            this.consumer = consumer;
+        }
+
+        @Override
+        public Message getMessage() {
+            return new PolledMessageWrapper<>(message);
+        }
+
+        @Override
+        public void onConsumed(MessageConsumptionStatus status) {
+            if (status == MessageConsumptionStatus.SENT || status == MessageConsumptionStatus.FILTERED) {
+                consumer.commitIndividualAsync(message).join(); // TODO: good?
+            }
+        }
+    }
+
+    // dummy class for poc
+    static class PolledMessageWrapper<O extends Offset> extends Message {
+        PolledMessage<O> polledMessage;
+
+        public PolledMessageWrapper(PolledMessage<O> polledMessage) {
+            super(polledMessage.getPayload(), null);
+            this.polledMessage = polledMessage;
+        }
+    }
+}

--- a/consumer/src/main/java/com/flipkart/varadhi/consumer/UnGroupedMessageSrc.java
+++ b/consumer/src/main/java/com/flipkart/varadhi/consumer/UnGroupedMessageSrc.java
@@ -6,16 +6,15 @@ import com.flipkart.varadhi.spi.services.PolledMessage;
 import com.flipkart.varadhi.spi.services.PolledMessages;
 import lombok.RequiredArgsConstructor;
 
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 @RequiredArgsConstructor
 public class UnGroupedMessageSrc<O extends Offset> implements MessageSrc {
 
     final Consumer<O> consumer;
 
-    private final BlockingQueue<MessageTracker> buffer = new LinkedBlockingQueue<>();
+    private final ConcurrentLinkedQueue<MessageTracker> buffer = new ConcurrentLinkedQueue<>();
 
     @Override
     public CompletableFuture<Integer> nextMessages(MessageTracker[] messages) {
@@ -34,7 +33,7 @@ public class UnGroupedMessageSrc<O extends Offset> implements MessageSrc {
             if (i < messages.length) {
                 messages[i++] = messageTracker;
             } else {
-                buffer.add(messageTracker);
+                buffer.offer(messageTracker);
             }
         }
         return i;

--- a/consumer/src/main/java/com/flipkart/varadhi/consumer/UnGroupedMessageSrc.java
+++ b/consumer/src/main/java/com/flipkart/varadhi/consumer/UnGroupedMessageSrc.java
@@ -6,8 +6,9 @@ import com.flipkart.varadhi.spi.services.PolledMessage;
 import com.flipkart.varadhi.spi.services.PolledMessages;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Message source that does not maintain any kind of ordering.
@@ -17,14 +18,15 @@ public class UnGroupedMessageSrc<O extends Offset> implements MessageSrc {
 
     private final Consumer<O> consumer;
 
-    /**
-     * Lock free buffer to store excess messages in case the consumer fetches a batch larger than the requested size.
-     */
-    private final ConcurrentLinkedQueue<MessageTracker> buffer = new ConcurrentLinkedQueue<>();
+    // flag to indicate whether a future is in progress to fetch messages from the consumer.
+    private final AtomicBoolean futureInProgress = new AtomicBoolean(false);
+
+    // Iterator into an ongoing consumer batch that has not been fully processed yet.
+    private Iterator<PolledMessage<O>> ongoingIterator = null;
 
     /**
      * Fetches the next batch of messages from the consumer.
-     * Attempts to first fetch from the buffer and then from the consumer.
+     * Prioritise immediate fetch and return over waiting for the consumer.
      *
      * @param messages Array of message trackers to populate.
      *
@@ -32,31 +34,54 @@ public class UnGroupedMessageSrc<O extends Offset> implements MessageSrc {
      */
     @Override
     public CompletableFuture<Integer> nextMessages(MessageTracker[] messages) {
-        int offset = fetchFromBuffer(messages);
-        if (offset < messages.length) {
-            return consumer.receiveAsync()
-                    .thenApply(polledMessages -> processPolledMessages(offset, polledMessages, messages));
+        // Iterator of consumer batch is cached when consumer batch size is more than messages size.
+        // Our first priority is to drain the iterator if it is set and return immediately.
+        // We do not want to proceed with consumer receiveAsync if we have messages in the iterator,
+        // as a slow or empty consumer might block the flow and cause the iterator contents to be stuck.
+        int offset = fetchFromIterator(messages);
+        if (offset > 0) {
+            return CompletableFuture.completedFuture(offset);
         }
-        return CompletableFuture.completedFuture(offset);
+
+        // If the iterator is not set, or is empty, then we try to fetch the message batch from the consumer.
+        // However, multiple calls to nextMessages may fire multiple futures concurrently.
+        // Leading to a race condition that overrides the iterator from a previous un-processed batch, causing a lost-update problem.
+        // Therefore, we use the futureInProgress flag to limit the concurrency and ensure only one future is in progress at a time.
+        if (futureInProgress.compareAndSet(false, true)) {
+            return consumer.receiveAsync()
+                    .thenApply(polledMessages -> processPolledMessages(offset, polledMessages, messages))
+                    .whenComplete((result, ex) -> futureInProgress.set(
+                            false)); // any of the above stages can complete exceptionally, so this is to ensure the flag is reset.
+        }
+        return CompletableFuture.completedFuture(0);
     }
 
     private int processPolledMessages(int offset, PolledMessages<O> polledMessages, MessageTracker[] messages) {
         int i = offset;
-        for (PolledMessage<O> polledMessage : polledMessages) {
+
+        Iterator<PolledMessage<O>> polledMessagesIterator = polledMessages.iterator();
+        while (polledMessagesIterator.hasNext() && i < messages.length) {
+            PolledMessage<O> polledMessage = polledMessagesIterator.next();
             MessageTracker messageTracker = new PolledMessageTracker<>(consumer, polledMessage);
-            if (i < messages.length) {
-                messages[i++] = messageTracker;
-            } else {
-                buffer.offer(messageTracker);
-            }
+            messages[i++] = messageTracker;
+        }
+
+        if (polledMessagesIterator.hasNext()) {
+            ongoingIterator = polledMessagesIterator;
         }
         return i;
     }
 
-    private int fetchFromBuffer(MessageTracker[] messages) {
+    private int fetchFromIterator(MessageTracker[] messages) {
+        if (ongoingIterator == null || !ongoingIterator.hasNext()) {
+            return 0;
+        }
+
         int i = 0;
-        while (i < messages.length && !buffer.isEmpty()) {
-            messages[i++] = buffer.poll();
+        while (i < messages.length && ongoingIterator.hasNext()) {
+            PolledMessage<O> polledMessage = ongoingIterator.next();
+            MessageTracker messageTracker = new PolledMessageTracker<>(consumer, polledMessage);
+            messages[i++] = messageTracker;
         }
         return i;
     }

--- a/consumer/src/main/java/com/flipkart/varadhi/consumer/UnGroupedMessageSrc.java
+++ b/consumer/src/main/java/com/flipkart/varadhi/consumer/UnGroupedMessageSrc.java
@@ -1,11 +1,9 @@
 package com.flipkart.varadhi.consumer;
 
-import com.flipkart.varadhi.entities.Message;
 import com.flipkart.varadhi.entities.Offset;
 import com.flipkart.varadhi.spi.services.Consumer;
 import com.flipkart.varadhi.spi.services.PolledMessage;
 import com.flipkart.varadhi.spi.services.PolledMessages;
-import com.google.common.collect.ArrayListMultimap;
 import lombok.RequiredArgsConstructor;
 
 import java.util.concurrent.BlockingQueue;
@@ -32,7 +30,7 @@ public class UnGroupedMessageSrc<O extends Offset> implements MessageSrc {
     private int processPolledMessages(int offset, PolledMessages<O> polledMessages, MessageTracker[] messages) {
         int i = offset;
         for (PolledMessage<O> polledMessage : polledMessages) {
-            MessageTracker messageTracker = new UnGroupedMessageTracker<>(consumer, polledMessage);
+            MessageTracker messageTracker = new PolledMessageTracker<>(consumer, polledMessage);
             if (i < messages.length) {
                 messages[i++] = messageTracker;
             } else {
@@ -48,15 +46,5 @@ public class UnGroupedMessageSrc<O extends Offset> implements MessageSrc {
             messages[i++] = buffer.poll();
         }
         return i;
-    }
-
-    // TODO(aayush): dummy class for poc
-    static class PolledMessageWrapper<O extends Offset> extends Message {
-        PolledMessage<O> polledMessage;
-
-        public PolledMessageWrapper(PolledMessage<O> polledMessage) {
-            super(polledMessage.getPayload(), ArrayListMultimap.create());
-            this.polledMessage = polledMessage;
-        }
     }
 }

--- a/consumer/src/main/java/com/flipkart/varadhi/consumer/UnGroupedMessageTracker.java
+++ b/consumer/src/main/java/com/flipkart/varadhi/consumer/UnGroupedMessageTracker.java
@@ -1,0 +1,28 @@
+package com.flipkart.varadhi.consumer;
+
+import com.flipkart.varadhi.entities.Message;
+import com.flipkart.varadhi.entities.Offset;
+import com.flipkart.varadhi.spi.services.Consumer;
+import com.flipkart.varadhi.spi.services.PolledMessage;
+
+public class UnGroupedMessageTracker<O extends Offset> implements MessageTracker {
+    private final PolledMessage<O> message;
+    private final Consumer<O> committer;
+
+    public UnGroupedMessageTracker(Consumer<O> committer, PolledMessage<O> message) {
+        this.message = message;
+        this.committer = committer;
+    }
+
+    @Override
+    public Message getMessage() {
+        return new UnGroupedMessageSrc.PolledMessageWrapper<>(message);
+    }
+
+    @Override
+    public void onConsumed(MessageConsumptionStatus status) {
+        if (status == MessageConsumptionStatus.SENT || status == MessageConsumptionStatus.FILTERED) {
+            committer.commitIndividualAsync(message);
+        }
+    }
+}

--- a/consumer/src/main/java/module-info.java
+++ b/consumer/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module com.flipkart.varadhi.consumer {
     requires java.base;
     requires com.google.common;
     requires io.netty.common;
+    requires org.apache.commons.lang3;
 
     requires com.flipkart.varadhi.common;
     requires com.flipkart.varadhi.entities;

--- a/consumer/src/test/java/com/flipkart/varadhi/consumer/UnGroupedMessageSrcTest.java
+++ b/consumer/src/test/java/com/flipkart/varadhi/consumer/UnGroupedMessageSrcTest.java
@@ -1,0 +1,123 @@
+package com.flipkart.varadhi.consumer;
+
+import com.flipkart.varadhi.entities.Offset;
+import com.flipkart.varadhi.spi.services.Consumer;
+import com.flipkart.varadhi.spi.services.PolledMessage;
+import com.flipkart.varadhi.spi.services.PolledMessages;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+class UnGroupedMessageSrcTest {
+
+    @Test
+    void testMessageSrcDriver() {
+        Consumer<DummyOffset> consumer = new DummyConsumer();
+        UnGroupedMessageSrc<DummyOffset> messageSrc = new UnGroupedMessageSrc<>(consumer);
+        MessageTracker[] messages = new MessageTracker[3];
+        Integer res = messageSrc.nextMessages(messages).join();
+        for (MessageTracker message : messages) {
+            message.onConsumed(MessageConsumptionStatus.SENT);
+        }
+        Integer res2 = messageSrc.nextMessages(messages).join();
+        for (MessageTracker message : messages) {
+            message.onConsumed(MessageConsumptionStatus.SENT);
+        }
+        Assertions.assertEquals(3, res);
+        Assertions.assertEquals(1, res2);
+    }
+
+    static class DummyConsumer implements Consumer<DummyOffset> {
+        @Override
+        public CompletableFuture<PolledMessages<DummyOffset>> receiveAsync() {
+            return CompletableFuture.supplyAsync(() -> new PolledMessages<>() {
+                final List<String> messages = List.of("m1", "m2", "m3", "m4");
+
+                @Override
+                public int getCount() {
+                    return messages.size();
+                }
+
+                @Override
+                public Iterator<PolledMessage<DummyOffset>> iterator() {
+                    Iterator<String> iter = messages.iterator();
+                    return new Iterator<>() {
+                        @Override
+                        public boolean hasNext() {
+                            return iter.hasNext();
+                        }
+
+                        @Override
+                        public PolledMessage<DummyOffset> next() {
+                            var message = iter.next();
+                            return new PolledMessage<>() {
+                                @Override
+                                public String getTopicName() {
+                                    return null;
+                                }
+
+                                @Override
+                                public int getPartition() {
+                                    return 0;
+                                }
+
+                                @Override
+                                public DummyOffset getOffset() {
+                                    return new DummyOffset(1);
+                                }
+
+                                @Override
+                                public byte[] getPayload() {
+                                    return message.getBytes(StandardCharsets.UTF_8);
+                                }
+
+                                @Override
+                                public void release() {
+
+                                }
+                            };
+                        }
+                    };
+                }
+            });
+        }
+
+        @Override
+        public CompletableFuture<Void> commitCumulativeAsync(PolledMessage<DummyOffset> message) {
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<Void> commitIndividualAsync(PolledMessage<DummyOffset> message) {
+            return CompletableFuture.supplyAsync(() -> {
+                log.info("Committing message: {}", message.getPayload());
+                return null;
+            });
+        }
+
+        @Override
+        public void close() throws Exception {
+
+        }
+    }
+
+    public static class DummyOffset implements Offset {
+        int offset;
+
+        public DummyOffset(int offset) {
+            this.offset = offset;
+        }
+
+        @Override
+        public int compareTo(Offset o) {
+            return offset - ((DummyOffset) o).offset;
+        }
+    }
+
+}

--- a/spi/src/testFixtures/java/com/flipkart/varadhi/spi/services/DummyConsumer.java
+++ b/spi/src/testFixtures/java/com/flipkart/varadhi/spi/services/DummyConsumer.java
@@ -1,0 +1,129 @@
+package com.flipkart.varadhi.spi.services;
+
+import com.flipkart.varadhi.spi.services.DummyProducer.DummyOffset;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class DummyConsumer implements Consumer<DummyOffset> {
+
+    // allows to confirm the acknowledgement of messages
+    private final Map<String, Boolean> messages;
+    private boolean isCalled = false;
+
+    public DummyConsumer(List<String> messages) {
+        this.messages = messages.stream().map(message -> Map.entry(message, false))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public CompletableFuture<PolledMessages<DummyOffset>> receiveAsync() {
+        if (isCalled) {
+            // return empty iterator if the consumer is already called
+            return CompletableFuture.completedFuture(new PolledMessages<>() {
+                @Override
+                public int getCount() {
+                    return 0;
+                }
+
+                @Override
+                public Iterator<PolledMessage<DummyOffset>> iterator() {
+                    return new Iterator<>() {
+                        @Override
+                        public boolean hasNext() {
+                            return false;
+                        }
+
+                        @Override
+                        public PolledMessage<DummyOffset> next() {
+                            return null;
+                        }
+                    };
+                }
+            });
+        }
+
+        // mark the consumer as called to avoid multiple calls
+        isCalled = true;
+        return CompletableFuture.supplyAsync(() -> new PolledMessages<>() {
+            @Override
+            public int getCount() {
+                return messages.size();
+            }
+
+            @Override
+            public Iterator<PolledMessage<DummyOffset>> iterator() {
+                Iterator<String> iter = messages.keySet().iterator();
+                return new Iterator<>() {
+                    @Override
+                    public boolean hasNext() {
+                        return iter.hasNext();
+                    }
+
+                    @Override
+                    public PolledMessage<DummyOffset> next() {
+                        String message = iter.next();
+                        return new PolledMessage<>() {
+                            @Override
+                            public String getTopicName() {
+                                return null;
+                            }
+
+                            @Override
+                            public int getPartition() {
+                                return 0;
+                            }
+
+                            @Override
+                            public DummyOffset getOffset() {
+                                return new DummyOffset(1);
+                            }
+
+                            @Override
+                            public byte[] getPayload() {
+                                return message.getBytes(StandardCharsets.UTF_8);
+                            }
+
+                            @Override
+                            public void release() {
+                                // no op
+                            }
+                        };
+                    }
+                };
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Void> commitCumulativeAsync(PolledMessage<DummyOffset> message) {
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<Void> commitIndividualAsync(PolledMessage<DummyOffset> message) {
+        messages.put(new String(message.getPayload(), StandardCharsets.UTF_8), true);
+        return null;
+    }
+
+    public int getCommittedMessagesCount() {
+        return messages.entrySet().stream().filter(Map.Entry::getValue).mapToInt(entry -> 1).sum();
+    }
+
+    public List<String> getCommittedMessages() {
+        return messages.entrySet().stream().filter(Map.Entry::getValue).map(Map.Entry::getKey).toList();
+    }
+
+    public void permitMoreMessages() {
+        isCalled = false;
+    }
+
+    @Override
+    public void close() throws Exception {
+        // no op
+    }
+}

--- a/spi/src/testFixtures/java/com/flipkart/varadhi/spi/services/DummyConsumer.java
+++ b/spi/src/testFixtures/java/com/flipkart/varadhi/spi/services/DummyConsumer.java
@@ -126,4 +126,27 @@ public class DummyConsumer implements Consumer<DummyOffset> {
     public void close() throws Exception {
         // no op
     }
+
+    // Simulate a slow consumer that takes a delay to return each batch of messages
+    public static class SlowConsumer extends DummyConsumer {
+
+        private final long delayInSeconds;
+
+        public SlowConsumer(List<String> messages, int delayInSeconds) {
+            super(messages);
+            this.delayInSeconds = delayInSeconds;
+        }
+
+        @Override
+        public CompletableFuture<PolledMessages<DummyOffset>> receiveAsync() {
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    Thread.sleep(delayInSeconds * 1000L);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return super.receiveAsync().join();
+            });
+        }
+    }
 }


### PR DESCRIPTION
Implementation added for Grouped and UnGrouped Message source

UnGrouped messages source: Polls message batches from the consumer and populates the passed array. Extra messages are buffered in-mem in case of overflow. Subsequent calls will try to drain the buffer first.

Grouped message source: Polls one message per free groupId and populates the array. Further messages in a group will not be polled until the previous one gets committed.

This is still the initial implementation. Subject to change based on the final subscription consumer usage patterns.