### PR TITLE
Implement missing methods in PulsarMessage

### DIFF
--- a/pulsar/src/main/java/com/flipkart/varadhi/pulsar/entities/PulsarMessages.java
+++ b/pulsar/src/main/java/com/flipkart/varadhi/pulsar/entities/PulsarMessages.java
@@ -2,6 +2,7 @@ package com.flipkart.varadhi.pulsar.entities;
 
 import com.flipkart.varadhi.spi.services.PolledMessage;
 import com.flipkart.varadhi.spi.services.PolledMessages;
+import jakarta.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Messages;
@@ -19,6 +20,7 @@ public class PulsarMessages implements PolledMessages<PulsarOffset> {
     }
 
     @Override
+    @Nonnull
     public Iterator<PolledMessage<PulsarOffset>> iterator() {
         Iterator<Message<byte[]>> it = msgs.iterator();
         return new Iterator<>() {

--- a/pulsar/src/test/java/com/flipkart/varadhi/pulsar/entities/PulsarMessageTest.java
+++ b/pulsar/src/test/java/com/flipkart/varadhi/pulsar/entities/PulsarMessageTest.java
@@ -1,0 +1,55 @@
+package com.flipkart.varadhi.pulsar.entities;
+
+import com.flipkart.varadhi.entities.Message;
+import com.flipkart.varadhi.entities.ProducerMessage;
+import com.flipkart.varadhi.entities.StandardHeaders;
+import com.flipkart.varadhi.pulsar.util.PropertyHelper;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.impl.TypedMessageBuilderImpl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+class PulsarMessageTest {
+
+    @Test
+    void testPulsarMessagesEqualsProducerMessage() {
+        // test request headers
+        Multimap<String, String> requestHeaders = ArrayListMultimap.create();
+        requestHeaders.put("header1", "value1");
+        requestHeaders.put(StandardHeaders.MESSAGE_ID, "msgId");
+        requestHeaders.put(StandardHeaders.GROUP_ID, "grpId");
+        requestHeaders.putAll("header2", List.of("value2", "value3"));
+
+        // now create the producer message
+        Message producerMessage = new ProducerMessage("message".getBytes(StandardCharsets.UTF_8), requestHeaders);
+
+        // create produce path message builder
+        TypedMessageBuilder<byte[]> messageBuilder = new TypedMessageBuilderImpl<>(null, Schema.BYTES)
+                .key("key").value(producerMessage.getPayload());
+        producerMessage.getRequestHeaders().asMap()
+                .forEach((key, values) -> messageBuilder.property(key, PropertyHelper.encodePropertyValues(values)));
+
+        // create pulsar message, which is the message that is consumed by the consumer
+        PulsarMessage pulsarMessage =
+                new PulsarMessage(((TypedMessageBuilderImpl<byte[]>) messageBuilder).getMessage());
+
+        // pulsar message and producer message should match
+        Assertions.assertEquals(producerMessage.getMessageId(), pulsarMessage.getMessageId());
+        Assertions.assertEquals(producerMessage.getGroupId(), producerMessage.getGroupId());
+
+        Assertions.assertEquals(producerMessage.getRequestHeaders().size(), pulsarMessage.getRequestHeaders().size());
+        producerMessage.getRequestHeaders().asMap().forEach((key, values) -> {
+            Assertions.assertTrue(pulsarMessage.getRequestHeaders().containsKey(key));
+            Assertions.assertEquals(values, pulsarMessage.getRequestHeaders().get(key));
+        });
+
+    }
+
+
+}


### PR DESCRIPTION
This PR implements the missing methods in PulsarMessage which had dependency on the request headers which were passed in the Produce path.

Since, the produce path added the request headers as Pulsar API Message properties, all we need to do is to fetch the properties and extract all the key value pairs to rebuild the request headers.

Now we can implement the missing methods like getHeader(), getMessageId, getGroupId, etc