### PR TITLE
publish to maven central

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -2,7 +2,8 @@
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
 # documentation.
-# This workflow will build a package using Gradle and then publish it to GitHub packages when a release is created
+# This workflow will build a package using Gradle and then publish it to Maven Central.
+# Requires secrets: MAVEN_CENTRAL_USERNAME, MAVEN_CENTRAL_TOKEN, FOSS_GPG_KEY, FOSS_GPG_PASSPHRASE
 # For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-gradle
 
 name: Gradle Publish
@@ -19,7 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
@@ -32,15 +33,15 @@ jobs:
       with:
         gradle-version: "8.10.2"
 
-    - name: Execute Gradle build 
+    - name: Execute Gradle build
       run: ./gradlew clean build
 
-    # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
-    # the publishing section of your build.gradle
-    - name: Publish to Clojars repository
-      run: ./gradlew publish
+    # The com.vanniktech.maven.publish plugin reads these as Gradle project properties.
+    # ORG_GRADLE_PROJECT_<name> env vars are automatically exposed by Gradle as project properties.
+    - name: Publish to Maven Central repository
+      run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
       env:
-        CLOJARS_USERNAME: flipkartoss
-        CLOJARS_PASSWORD: ${{ secrets.DEPLOY_TOKEN }}
-        GPG_SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-        GPG_SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PWD }}
+        ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+        ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.FOSS_GPG_KEY }}
+        ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.FOSS_GPG_PASSPHRASE }}

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -39,7 +39,7 @@ jobs:
     # The com.vanniktech.maven.publish plugin reads these as Gradle project properties.
     # ORG_GRADLE_PROJECT_<name> env vars are automatically exposed by Gradle as project properties.
     - name: Publish to Maven Central repository
-      run: ./gradlew publishToMavenCentral --no-configuration-cache
+      run: ./gradlew publishToMavenCentral
       env:
         ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -39,7 +39,7 @@ jobs:
     # The com.vanniktech.maven.publish plugin reads these as Gradle project properties.
     # ORG_GRADLE_PROJECT_<name> env vars are automatically exposed by Gradle as project properties.
     - name: Publish to Maven Central repository
-      run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+      run: ./gradlew publishToMavenCentral --no-configuration-cache
       env:
         ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,3 +7,9 @@ repositories {
     // Use the plugin portal to apply community plugins in convention plugins.
     gradlePluginPortal()
 }
+
+dependencies {
+    // Makes the com.vanniktech.maven.publish plugin available to convention plugins
+    // so they can apply it via the plugins { } block.
+    implementation "com.vanniktech:gradle-maven-publish-plugin:0.30.0"
+}

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,5 +11,5 @@ repositories {
 dependencies {
     // Makes the com.vanniktech.maven.publish plugin available to convention plugins
     // so they can apply it via the plugins { } block.
-    implementation "com.vanniktech:gradle-maven-publish-plugin:0.30.0"
+    implementation "com.vanniktech:gradle-maven-publish-plugin:0.33.0"
 }

--- a/buildSrc/src/main/groovy/com.flipkart.varadhi.java-published-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.flipkart.varadhi.java-published-library-conventions.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
 
     // Publish an empty Javadoc jar (Maven Central requires the jar to exist).

--- a/buildSrc/src/main/groovy/com.flipkart.varadhi.java-published-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.flipkart.varadhi.java-published-library-conventions.gradle
@@ -1,51 +1,46 @@
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     id 'com.flipkart.varadhi.java-library-conventions'
-    // Apply the maven-publish to allow deploying to maven artifactories
-    id 'signing'
-    id 'maven-publish'
+    id 'com.vanniktech.maven.publish'
 }
 
-signing {
-    def signingKey = System.getenv("GPG_SIGNING_KEY")
-    def signingPassword = System.getenv("GPG_SIGNING_PASSPHRASE")
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications
-}
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
+    signAllPublications()
 
-publishing {
-    publications {
-        maven(MavenPublication) {
-            groupId = "${projectGroupId}"
-            artifactId = "${project.name}"
-            version = "${version}"
-            from components.java
+    // Publish an empty Javadoc jar (Maven Central requires the jar to exist).
+    // Lombok's onConstructor = @__(...) pattern breaks the standalone Javadoc tool;
+    // switch to JavadocJar.Javadoc() (or a delombok pipeline) once those usages are removed.
+    configure(new JavaLibrary(new JavadocJar.Empty(), true))
 
-            pom {
-                name = "${project.name}"
-                url = "https://github.com/flipkart-incubator/varadhi"
+    coordinates("${projectGroupId}", "${project.name}", "${version}")
+
+    pom {
+        name = "${project.name}"
+        description = "Varadhi - Flipkart's messaging infrastructure"
+        url = "https://github.com/flipkart-incubator/varadhi"
+
+        licenses {
+            license {
+                name = 'The Apache License, Version 2.0'
+                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
             }
         }
-    }
-
-    repositories {
-        maven {
-            name = "CLOJARS"
-            url = "https://repo.clojars.org"
-            credentials {
-                username = System.getenv("CLOJARS_USERNAME")
-                password = System.getenv("CLOJARS_PASSWORD")
+        developers {
+            developer {
+                id = 'flipkart-incubator'
+                name = 'Flipkart Incubator'
+                organization = 'Flipkart'
+                organizationUrl = 'https://github.com/flipkart-incubator'
             }
         }
-    }
-
-    publications.withType(MavenPublication).configureEach {
-        pom {
-            licenses {
-                license {
-                    name = 'The Apache License, Version 2.0'
-                    url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                }
-            }
+        scm {
+            connection = 'scm:git:git://github.com/flipkart-incubator/varadhi.git'
+            developerConnection = 'scm:git:ssh://git@github.com/flipkart-incubator/varadhi.git'
+            url = 'https://github.com/flipkart-incubator/varadhi'
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,3 @@ projectName=varadhi
 majorVersion=0
 minorVersion=1
 patchId=8-SNAPSHOT
-mavenPublishUrl="" # Add repository URL with double quotes removed
-systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ projectName=varadhi
 majorVersion=0
 minorVersion=1
 patchId=8-SNAPSHOT
+systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated artifact publishing to Maven Central and removed the prior repository publishing.
  * Introduced standardized Gradle publishing conventions with signing for all publications.
  * Improved POM metadata (project info, license, SCM, developers) and ensured Javadoc artifact handling.
  * Removed outdated/insecure publishing properties and simplified build publishing steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flipkart-incubator/varadhi/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->